### PR TITLE
Update solr and use less gem gits

### DIFF
--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -1,5 +1,4 @@
 # Place any default configuration for solr_wrapper here
-version: 6.1.0
 port: 8983
 instance_dir: tmp/solr-development
 collection:

--- a/Gemfile
+++ b/Gemfile
@@ -46,16 +46,16 @@ gem 'prawn'
 # gem 'pdf-inspector', '~> 1.2.0', group: [:test]
 
 # Copied from curation_concerns Gemfile.extra
-gem 'hydra-works', github: 'projecthydra-labs/hydra-works', branch: 'master'
-gem 'hydra-pcdm', github: 'projecthydra-labs/hydra-pcdm', branch: 'master'
-gem 'hydra-derivatives', github: 'projecthydra/hydra-derivatives', branch: 'master'
-gem 'active-fedora', github: 'projecthydra/active_fedora', branch: 'master'
+gem 'hydra-works'#, github: 'projecthydra-labs/hydra-works', branch: 'master'
+gem 'hydra-pcdm'#, github: 'projecthydra-labs/hydra-pcdm', branch: 'master'
+gem 'hydra-derivatives'#, github: 'projecthydra/hydra-derivatives', branch: 'master'
+gem 'active-fedora'#, github: 'projecthydra/active_fedora', branch: 'master'
 
 gem 'rubocop', '~> 0.34.0', require: false
 gem 'rubocop-rspec', '~> 1.3.0', require: false
 
 group :development, :test do
-  gem 'simplecov', '~> 0.9', require: false
+  gem 'simplecov', require: false
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'pry-byebug'
   gem 'rspec-rails'
@@ -66,9 +66,9 @@ group :development, :test do
   gem 'pry-rails'
 end
 
-gem 'solr_wrapper', '~> 0.13.0'
-gem 'fcrepo_wrapper', '~> 0.5.0'
-gem 'coveralls', '0.8.3', require: false
+gem 'solr_wrapper'
+gem 'fcrepo_wrapper'
+gem 'coveralls', require: false
 
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,21 +26,22 @@ GIT
 
 GIT
   remote: git://github.com/projecthydra-labs/curation_concerns.git
-  revision: e18cb74c42af681fa3342c2d02de3a7121670499
+  revision: 4c3329d25bfee43107515c22074089c0e8975d72
   branch: member_of_replace
   specs:
-    curation_concerns (1.4.0)
+    curation_concerns (1.5.0)
       active-fedora (>= 10.3.0.rc1)
       active_attr
       active_fedora-noid (~> 2.0.0.beta1)
       awesome_nested_set (~> 3.0)
       blacklight (~> 6.3)
       blacklight_advanced_search (~> 6.0)
-      breadcrumbs_on_rails (>= 2.3, < 4)
+      breadcrumbs_on_rails (>= 3.0.1, < 4)
       browse-everything (~> 0.10)
       clipboard-rails (~> 1.5)
       hydra-editor (>= 2, < 4)
       hydra-head (>= 10.0.0, < 11)
+      hydra-pcdm (~> 0.9.0)
       hydra-works (>= 0.12.0)
       jquery-ui-rails
       kaminari_route_prefix (~> 0.0.1)
@@ -55,19 +56,19 @@ GIT
 
 GIT
   remote: git://github.com/projecthydra-labs/hydra-pcdm.git
-  revision: 57d18d0c42cb572412782546ae8795fd2cf7617f
+  revision: 854e13cc324e95fd329eb0a812815d2d78abf951
   branch: master
   specs:
-    hydra-pcdm (0.8.2)
+    hydra-pcdm (0.9.0)
       active-fedora (>= 10, < 12)
       mime-types (>= 1)
 
 GIT
   remote: git://github.com/projecthydra-labs/hydra-works.git
-  revision: 9790d224a713d60ae92849691b52e79689f6c3c7
+  revision: a73a54143243c9eb3ac279355f995497fa5fa4a3
   branch: master
   specs:
-    hydra-works (0.12.0)
+    hydra-works (0.13.0)
       hydra-derivatives (~> 3.0)
       hydra-file_characterization (~> 0.3, >= 0.3.3)
       hydra-pcdm (>= 0.8)
@@ -75,7 +76,7 @@ GIT
 
 GIT
   remote: git://github.com/projecthydra/active_fedora.git
-  revision: a7a5364b54e15a6eae20aa13a9b58175911bd126
+  revision: 5516fcda30aa5618a4b8137e78d065b252077f41
   branch: master
   specs:
     active-fedora (11.0.0.rc7)
@@ -222,7 +223,7 @@ GEM
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
     bootstrap_form (2.5.0)
-    breadcrumbs_on_rails (3.0.0)
+    breadcrumbs_on_rails (3.0.1)
     builder (3.2.2)
     bunny (2.5.1)
       amq-protocol (>= 2.0.1)
@@ -242,7 +243,7 @@ GEM
       capistrano-bundler (~> 1.1)
     capistrano-rails-console (1.0.2)
       capistrano (>= 3.1.0, < 4.0.0)
-    capybara (2.8.0)
+    capybara (2.8.1)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -375,9 +376,9 @@ GEM
       cancancan
     i18n (0.7.0)
     iso-639 (0.2.8)
-    jasmine-core (2.4.1)
+    jasmine-core (2.5.0)
     jasmine-jquery-rails (2.0.3)
-    jasmine-rails (0.12.6)
+    jasmine-rails (0.13.0)
       jasmine-core (>= 1.3, < 3.0)
       phantomjs (>= 1.9)
       railties (>= 3.2.0)
@@ -425,7 +426,7 @@ GEM
     marc (1.0.0)
       scrub_rb (>= 1.0.1, < 2)
       unf
-    memoist (0.14.0)
+    memoist (0.15.0)
     method_source (0.8.2)
     mime-types (2.99.2)
     mimemagic (0.3.2)
@@ -440,7 +441,7 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (3.2.0)
     netrc (0.11.0)
-    newrelic_rpm (3.16.1.320)
+    newrelic_rpm (3.16.2.321)
     noid (0.9.0)
     nokogiri (1.6.6.4)
       mini_portile (~> 0.6.0)
@@ -566,7 +567,7 @@ GEM
     rspec-mocks (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
-    rspec-rails (3.5.1)
+    rspec-rails (3.5.2)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       railties (>= 3.0)
@@ -587,7 +588,7 @@ GEM
       json
       multipart-post
       oauth2
-    ruby-prof (0.15.9)
+    ruby-prof (0.16.2)
     ruby-progressbar (1.8.1)
     ruby-rc4 (0.1.5)
     rubyzip (1.2.0)
@@ -613,7 +614,7 @@ GEM
       faraday (~> 0.9)
       jwt (~> 1.5)
       multi_json (~> 1.10)
-    simple_form (3.2.1)
+    simple_form (3.3.1)
       actionpack (> 4, < 5.1)
       activemodel (> 4, < 5.1)
     simplecov (0.10.0)
@@ -674,7 +675,7 @@ GEM
       railties (>= 3.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uglifier (3.0.1)
+    uglifier (3.0.2)
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,52 +55,6 @@ GIT
       sprockets-es6
 
 GIT
-  remote: git://github.com/projecthydra-labs/hydra-pcdm.git
-  revision: 854e13cc324e95fd329eb0a812815d2d78abf951
-  branch: master
-  specs:
-    hydra-pcdm (0.9.0)
-      active-fedora (>= 10, < 12)
-      mime-types (>= 1)
-
-GIT
-  remote: git://github.com/projecthydra-labs/hydra-works.git
-  revision: a73a54143243c9eb3ac279355f995497fa5fa4a3
-  branch: master
-  specs:
-    hydra-works (0.13.0)
-      hydra-derivatives (~> 3.0)
-      hydra-file_characterization (~> 0.3, >= 0.3.3)
-      hydra-pcdm (>= 0.8)
-      om (~> 3.1)
-
-GIT
-  remote: git://github.com/projecthydra/active_fedora.git
-  revision: 5516fcda30aa5618a4b8137e78d065b252077f41
-  branch: master
-  specs:
-    active-fedora (11.0.0.rc7)
-      active-triples (~> 0.10.0)
-      activemodel (>= 4.2, < 6)
-      activesupport (>= 4.2.4, < 6)
-      deprecation
-      ldp (~> 0.6.0)
-      rsolr (~> 1.1, >= 1.1.2)
-      solrizer (~> 3.4)
-
-GIT
-  remote: git://github.com/projecthydra/hydra-derivatives.git
-  revision: 26d2a6f46d740da68f7ecab62c1010603451838d
-  branch: master
-  specs:
-    hydra-derivatives (3.1.2)
-      active-fedora (>= 9.0, < 11)
-      activesupport (>= 4.0, < 6)
-      deprecation
-      mime-types (> 2.0, < 4.0)
-      mini_magick (>= 3.2, < 5)
-
-GIT
   remote: git://github.com/pulibrary/pul_metadata_services.git
   revision: c485eeff36d56c12255a95e5449727370820d53e
   branch: master
@@ -147,6 +101,14 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    active-fedora (11.0.0.rc7)
+      active-triples (~> 0.10.0)
+      activemodel (>= 4.2, < 6)
+      activesupport (>= 4.2.4, < 6)
+      deprecation
+      ldp (~> 0.6.0)
+      rsolr (~> 1.0, >= 1.0.10)
+      solrizer (~> 3.4)
     active-triples (0.10.2)
       activemodel (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -261,12 +223,12 @@ GEM
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.2)
     connection_pool (2.2.0)
-    coveralls (0.8.3)
-      json (~> 1.8)
-      rest-client (>= 1.6.8, < 2)
-      simplecov (~> 0.10.0)
+    coveralls (0.8.15)
+      json (>= 1.8, < 3)
+      simplecov (~> 0.12.0)
       term-ansicolor (~> 1.3)
       thor (~> 0.19.1)
+      tins (>= 1.6.0, < 2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     daemons (1.2.4)
@@ -284,8 +246,6 @@ GEM
       devise
     diff-lcs (1.2.5)
     docile (1.1.5)
-    domain_name (0.5.20160615)
-      unf (>= 0.0.5, < 1.0.0)
     dropbox-sdk (1.6.5)
       json
     ebnf (1.0.1)
@@ -303,7 +263,7 @@ GEM
       railties (>= 3.0.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    fcrepo_wrapper (0.5.2)
+    fcrepo_wrapper (0.6.0)
       ruby-progressbar
     font-awesome-rails (4.6.3.1)
       railties (>= 3.2, < 5.1)
@@ -342,21 +302,25 @@ GEM
       httparty (>= 0.7.3)
       mimemagic
       multipart-post
-    http-cookie (1.0.2)
-      domain_name (~> 0.5)
     http_logger (0.5.1)
     httparty (0.14.0)
       multi_xml (>= 0.5.2)
-    hydra-access-controls (10.2.0)
-      active-fedora (>= 10.0.0, < 12)
+    hydra-access-controls (10.1.0)
+      active-fedora (>= 10.0.0.beta1, < 11)
       activesupport (>= 4, < 6)
       blacklight (>= 5.16)
       blacklight-access_controls (~> 0.5)
       cancancan (~> 1.8)
       deprecation (~> 1.0)
-    hydra-core (10.2.0)
-      hydra-access-controls (= 10.2.0)
+    hydra-core (10.1.0)
+      hydra-access-controls (= 10.1.0)
       railties (>= 4.0.0, < 6)
+    hydra-derivatives (3.1.2)
+      active-fedora (>= 9.0, < 11)
+      activesupport (>= 4.0, < 6)
+      deprecation
+      mime-types (> 2.0, < 4.0)
+      mini_magick (>= 3.2, < 5)
     hydra-editor (3.1.0)
       active-fedora (>= 9.0.0)
       almond-rails (~> 0.0.3)
@@ -366,14 +330,22 @@ GEM
       sprockets-es6
     hydra-file_characterization (0.3.3)
       activesupport (>= 3.0.0)
-    hydra-head (10.2.0)
-      hydra-access-controls (= 10.2.0)
-      hydra-core (= 10.2.0)
+    hydra-head (10.1.0)
+      hydra-access-controls (= 10.1.0)
+      hydra-core (= 10.1.0)
       rails (>= 3.2.6)
+    hydra-pcdm (0.9.0)
+      active-fedora (>= 10, < 12)
+      mime-types (>= 1)
     hydra-role-management (0.2.2)
       blacklight
       bootstrap_form
       cancancan
+    hydra-works (0.13.0)
+      hydra-derivatives (~> 3.0)
+      hydra-file_characterization (~> 0.3, >= 0.3.3)
+      hydra-pcdm (>= 0.8)
+      om (~> 3.1)
     i18n (0.7.0)
     iso-639 (0.2.8)
     jasmine-core (2.5.0)
@@ -428,7 +400,9 @@ GEM
       unf
     memoist (0.15.0)
     method_source (0.8.2)
-    mime-types (2.99.2)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
     mimemagic (0.3.2)
     mini_magick (4.5.1)
     mini_portile (0.6.2)
@@ -440,7 +414,6 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (3.2.0)
-    netrc (0.11.0)
     newrelic_rpm (3.16.2.321)
     noid (0.9.0)
     nokogiri (1.6.6.4)
@@ -552,10 +525,6 @@ GEM
       redis (~> 3, >= 3.0.0)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
-    rest-client (1.8.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
     retriable (1.4.1)
     rsolr (1.1.2)
       builder (>= 2.1.2)
@@ -617,9 +586,9 @@ GEM
     simple_form (3.3.1)
       actionpack (> 4, < 5.1)
       activemodel (> 4, < 5.1)
-    simplecov (0.10.0)
+    simplecov (0.12.0)
       docile (~> 1.1.0)
-      json (~> 1.8)
+      json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     sinatra (1.4.7)
@@ -632,7 +601,7 @@ GEM
       httparty (>= 0.11.0)
       oauth2 (>= 0.9.2)
     slop (3.6.0)
-    solr_wrapper (0.13.2)
+    solr_wrapper (0.16.0)
       faraday
       ruby-progressbar
       rubyzip
@@ -701,7 +670,7 @@ PLATFORMS
 
 DEPENDENCIES
   aasm
-  active-fedora!
+  active-fedora
   arabic-letter-connector
   browse-everything!
   bunny
@@ -711,17 +680,17 @@ DEPENDENCIES
   capistrano-rails-console
   capybara
   coffee-rails (~> 4.1.0)
-  coveralls (= 0.8.3)
+  coveralls
   curation_concerns!
   devise (~> 3.0)
   devise-guests (~> 0.3)
   ezid-client
   factory_girl_rails
-  fcrepo_wrapper (~> 0.5.0)
-  hydra-derivatives!
-  hydra-pcdm!
+  fcrepo_wrapper
+  hydra-derivatives
+  hydra-pcdm
   hydra-role-management (~> 0.2.0)
-  hydra-works!
+  hydra-works
   iiif-presentation!
   iso-639
   jasmine-jquery-rails
@@ -754,9 +723,9 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   sidekiq
-  simplecov (~> 0.9)
+  simplecov
   sinatra
-  solr_wrapper (~> 0.13.0)
+  solr_wrapper
   spring
   sprockets (~> 3.5.0)
   sprockets-es6

--- a/config/solr_wrapper_test.yml
+++ b/config/solr_wrapper_test.yml
@@ -1,5 +1,4 @@
 #config/solr_wrapper_test.yml
-version: 6.1.0
 port: 8985
 instance_dir: tmp/solr-test
 collection:


### PR DESCRIPTION
Updates the solr_wrapper gem and the verson of solr it downloads.
Updates to the Gemfile include updating some old versions of build tools, and trying to not use git masters for several hydra gems.
