### PR TITLE
HPT-825 Fixing relative file paths to include Rails.root

### DIFF
--- a/app/authorities/holding_location_authority.rb
+++ b/app/authorities/holding_location_authority.rb
@@ -10,6 +10,6 @@ class HoldingLocationAuthority
   private
 
     def digital_locations
-      @digital_locations ||= YAML.load(File.read('config/digital_locations.yml'))
+      @digital_locations ||= YAML.load(File.read(Rails.root.join('config/digital_locations.yml')))
     end
 end

--- a/app/models/jsonld_record.rb
+++ b/app/models/jsonld_record.rb
@@ -71,7 +71,7 @@ class JSONLDRecord
       @outbound_graph ||= generate_outbound_graph
     end
 
-    CONTEXT = YAML.load(File.read('config/context.yml'))
+    CONTEXT = YAML.load(File.read(Rails.root.join('config/context.yml')))
 
     def generate_outbound_graph
       jsonld_hash = {}


### PR DESCRIPTION
The Ruby/Rails environment on the shared server is installed from Redhat package collections, and it has trouble resolving relative filespecs. It's usually safest to include Rails.root to ensure compatibility, which fixes the loading of 2 YAML files added in HPT-781.
