### PR TITLE
[HPT-831] File Manager: added button to sort files by label (from aploshay fork)

### DIFF
--- a/app/controllers/curation_concerns/curation_concerns_controller.rb
+++ b/app/controllers/curation_concerns/curation_concerns_controller.rb
@@ -14,6 +14,13 @@ class CurationConcerns::CurationConcernsController < ApplicationController
     super
   end
 
+  def alphabetize_members
+    @sorted = curation_concern.members.sort { |x, y| x.label <=> y.label }
+    flash[:notice] = "Files have been ordered alphabetically, by filename."
+    curation_concern.update_attributes(ordered_members: @sorted)
+    redirect_to :back
+  end
+
   def destroy
     messenger.record_deleted(curation_concern)
     super

--- a/app/views/curation_concerns/base/file_manager.html.erb
+++ b/app/views/curation_concerns/base/file_manager.html.erb
@@ -6,7 +6,11 @@
   <li><%= link_to @presenter, ContextualPath.new(@presenter, @parent_presenter).show %></li>
   <li class="active">File Manager</li>
 </ul>
-
+<% if @presenter.logical_order.empty? %>
+<div>
+  <%= link_to 'Sort files alphabetically', polymorphic_path([main_app, :alphabetize_members, @presenter]), method: :patch, class: "btn btn-primary" %>
+</div>
+<% end %>
 <% if !@presenter.member_presenters.empty? %>
   <div data-action="file-manager">
     <div class="col-md-3" id="file-manager-tools">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do
         get :manifest, defaults: { format: :json }
         post :flag
         post :browse_everything_files
+        patch :alphabetize_members
         get :structure
         post :structure, action: :save_structure
       end
@@ -63,6 +64,7 @@ Rails.application.routes.draw do
     resources :scanned_resources, only: [] do
       member do
         get "/pdf/:pdf_quality", action: :pdf, as: :pdf
+        patch :alphabetize_members
         get :structure
         post :structure, action: :save_structure
         get :manifest, defaults: { format: :json }

--- a/spec/controllers/curation_concerns/multi_volume_works_controller_spec.rb
+++ b/spec/controllers/curation_concerns/multi_volume_works_controller_spec.rb
@@ -6,6 +6,10 @@ describe CurationConcerns::MultiVolumeWorksController do
   let(:user) { FactoryGirl.create(:user) }
   let(:multi_volume_work) { FactoryGirl.create(:multi_volume_work, user: user, title: ['Dummy Title']) }
 
+  include_examples "alphabetize_members" do
+    let(:curation_concern) { multi_volume_work }
+  end
+
   describe "create" do
     let(:user) { FactoryGirl.create(:admin) }
     before do

--- a/spec/controllers/curation_concerns/scanned_resources_controller_spec.rb
+++ b/spec/controllers/curation_concerns/scanned_resources_controller_spec.rb
@@ -5,6 +5,10 @@ describe CurationConcerns::ScannedResourcesController do
   let(:scanned_resource) { FactoryGirl.create(:scanned_resource, user: user, title: ['Dummy Title'], state: 'complete', identifier: 'ark:/99999/fk4445wg45') }
   let(:reloaded) { scanned_resource.reload }
 
+  include_examples "alphabetize_members" do
+    let(:curation_concern) { scanned_resource }
+  end
+
   describe "delete" do
     let(:user) { FactoryGirl.create(:admin) }
     before do

--- a/spec/support/shared_examples/alphabetize_members.rb
+++ b/spec/support/shared_examples/alphabetize_members.rb
@@ -6,14 +6,13 @@ RSpec.shared_examples "alphabetize_members" do
     before do
       sign_in FactoryGirl.create(:admin)
       request.env['HTTP_REFERER'] = ':back'
-      curation_concern.members << fileB
-      curation_concern.members << fileA
+      curation_concern.update_attributes(ordered_members: [fileB, fileA])
       patch :alphabetize_members, id: curation_concern.id
     end
     it "reorders filesets by label" do
-      expect(curation_concern.members.to_a.first).to eq fileB
+      expect(curation_concern.ordered_members.to_a.first).to eq fileB
       curation_concern.reload
-      expect(curation_concern.members.to_a.first).to eq fileA
+      expect(curation_concern.ordered_members.to_a.first).to eq fileA
     end
     it "redirects to :back" do
       expect(response).to redirect_to ':back'

--- a/spec/support/shared_examples/alphabetize_members.rb
+++ b/spec/support/shared_examples/alphabetize_members.rb
@@ -1,0 +1,22 @@
+RSpec.shared_examples "alphabetize_members" do
+  # rubocop:disable RSpec/DescribeClass
+  describe "#alphabetize_members" do
+    let(:fileA) { FactoryGirl.create :file_set, label: 'A' }
+    let(:fileB) { FactoryGirl.create :file_set, label: 'B' }
+    before do
+      sign_in FactoryGirl.create(:admin)
+      request.env['HTTP_REFERER'] = ':back'
+      curation_concern.members << fileB
+      curation_concern.members << fileA
+      patch :alphabetize_members, id: curation_concern.id
+    end
+    it "reorders filesets by label" do
+      expect(curation_concern.members.to_a.first).to eq fileB
+      curation_concern.reload
+      expect(curation_concern.members.to_a.first).to eq fileA
+    end
+    it "redirects to :back" do
+      expect(response).to redirect_to ':back'
+    end
+  end
+end


### PR DESCRIPTION
Until file upload results can be made deterministic based on the upload queue, this is a possibility for adding 1-click re-sort of files.
