### PR TITLE
Pin down Ruby version to prevent surprises.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 require: rubocop-rspec
 
 AllCops:
+  TargetRubyVersion: 2.3
   RunRailsCops: true
   DisplayCopNames: true
   Include:

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,8 @@
 source 'https://rubygems.org'
 
+# Complain if developer not using the common Ruby version
+ruby '2.3.1'
+
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.7.1'
 # Use SCSS for stylesheets


### PR DESCRIPTION
The Gemfile mod. will complain if one uses some other version of Ruby, and would have helped me when I was still using 2.1.

The RuboCop mod. was necessary to prevent an offense w.r.t. the new safe-navigation operator in Ruby 2.3.