### PR TITLE
[HPT-826] New Variations fields in preingest

### DIFF
--- a/app/models/concerns/preingestable_document.rb
+++ b/app/models/concerns/preingestable_document.rb
@@ -7,7 +7,11 @@ module PreingestableDocument
   }
 
   def attributes
-    { default: DEFAULT_ATTRIBUTES, local: local_attributes, remote: remote_attributes }
+    { default: default_attributes, local: local_attributes, remote: remote_attributes }
+  end
+
+  def default_attributes
+    DEFAULT_ATTRIBUTES
   end
 
   def local_attributes

--- a/app/models/variations_document.rb
+++ b/app/models/variations_document.rb
@@ -25,6 +25,10 @@ class VariationsDocument
     'left-to-right'
   end
 
+  def viewing_hint
+    'paged'
+  end
+
   def location
     @variations.xpath('//Container/PhysicalID/Location').first&.content.to_s
   end
@@ -41,7 +45,7 @@ class VariationsDocument
   end
 
   def default_attributes
-    super.merge(visibility: visibility, rights_statement: rights_statement)
+    super.merge(visibility: visibility, rights_statement: rights_statement, viewing_hint: viewing_hint)
   end
 
   def local_attributes

--- a/app/models/variations_document.rb
+++ b/app/models/variations_document.rb
@@ -35,16 +35,52 @@ class VariationsDocument
       'https://libraries.indiana.edu/music'
     when 'Personal Collection'
       ''
-    # FIXME: abstract to loop through digital_locations?
     else
       ''
     end
   end
 
+  def default_attributes
+    super.merge(visibility: visibility, rights_statement: rights_statement)
+  end
+
   def local_attributes
     { source_metadata_identifier: source_metadata_identifier,
-      viewing_direction: viewing_direction
+      identifier: identifier,
+      holding_location: holding_location,
+      physical_description: physical_description,
+      copyright_holder: copyright_holder
     }
+  end
+
+  def identifier
+    'http://purl.dlib.indiana.edu/iudl/variations/score/' + source_metadata_identifier
+  end
+
+  def physical_description
+    @variations.xpath("//Container/DocumentInfos/DocumentInfo[Type='Score']/Description").first&.content.to_s
+  end
+
+  def copyright_holder
+    @variations.xpath("//Container/CopyrightDecls/CopyrightDecl/Owner").map(&:content)
+  end
+
+  def holding_status
+    @variations.xpath('//Container/HoldingStatus').first&.content.to_s
+  end
+
+  def visibility
+    if holding_status == 'Publicly available'
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    elsif holding_location == 'Personal Collection'
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    else
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+    end
+  end
+
+  def rights_statement
+    'http://rightsstatements.org/vocab/InC/1.0/'
   end
 
   def multi_volume?

--- a/app/schemas/plum_schema.rb
+++ b/app/schemas/plum_schema.rb
@@ -11,7 +11,7 @@ class PlumSchema < ActiveTriples::Schema
   property :source_metadata, predicate: ::PULTerms.source_metadata, multiple: false
   property :state, predicate: ::F3Access.objState, multiple: false
   property :workflow_note, predicate: ::RDF::Vocab::MODS.note
-  property :holding_location, predicate: ::RDF::Vocab::Bibframe.heldBy, multiple: false
+  property :holding_location, predicate: RDF::URI("http://id.loc.gov/ontologies/bibframe/heldBy"), multiple: false
   property :ocr_language, predicate: ::PULTerms.ocr_language
   property :nav_date, predicate: ::RDF::URI("http://iiif.io/api/presentation/2#navDate"), multiple: false
   property :pdf_type, predicate: ::PULTerms.pdf_type
@@ -23,7 +23,9 @@ class PlumSchema < ActiveTriples::Schema
   property :source, predicate: RDF::Vocab::DC11.source
   property :extent, predicate: RDF::Vocab::DC.extent
   property :edition, predicate: RDF::URI("http://id.loc.gov/ontologies/bibframe/editionStatement")
+  property :series, predicate: RDF::URI("http://id.loc.gov/ontologies/bibframe/seriesStatement")
   property :call_number, predicate: PULTerms.call_number
+  property :physical_description, predicate: RDF::Vocab::MODS.physicalExtent, multiple: false
   property :abridger, predicate: RDF::Vocab::MARCRelators.abr
   property :actor, predicate: RDF::Vocab::MARCRelators.act
   property :adapter, predicate: RDF::Vocab::MARCRelators.adp

--- a/config/context.yml
+++ b/config/context.yml
@@ -6,6 +6,7 @@
   bf: http://id.loc.gov/ontologies/bibframe/
   dc: http://purl.org/dc/elements/1.1/
   dcterms: http://purl.org/dc/terms/
+  mods: http://www.loc.gov/mods/rdf/v1#
   mrel: http://id.loc.gov/vocabulary/relators/
   pulterms: http://library.princeton.edu/terms/
   rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
@@ -48,8 +49,14 @@
     "@id": dcterms:title
   edition:
     "@id": bf:editionStatement
+  holding_location:
+    "@id": bf:heldBy
+  series:
+    "@id": bf:seriesStatement
   call_number:
     "@id": pulterms:call_number
+  physical_description:
+    "@id": mods:physicalExtent
   abridger:
     "@id": mrel:abr
   actor:

--- a/spec/fixtures/variations_xml/abe9721.yml
+++ b/spec/fixtures/variations_xml/abe9721.yml
@@ -4,11 +4,15 @@
   :default:
     :state: final_review
     :viewing_direction: left-to-right
-    :rights_statement: http://rightsstatements.org/vocab/NKC/1.0/
-    :visibility: open
+    :rights_statement: http://rightsstatements.org/vocab/InC/1.0/
+    :visibility: authenticated
   :local:
     :source_metadata_identifier: ABE9721
-    :viewing_direction: left-to-right
+    :identifier: http://purl.dlib.indiana.edu/iudl/variations/score/ABE9721
+    :holding_location: https://libraries.indiana.edu/music
+    :physical_description: "   v. of music : facsims. ; 36 x 44 cm"
+    :copyright_holder:
+    - "(C) 1990 Fryderyk Chopin Society; Green Peace Pub."
   :remote:
     title:
     - 'The facsimil[e] edition of the autograph of Fryderyk Chopin''s works : from

--- a/spec/fixtures/variations_xml/abe9721.yml
+++ b/spec/fixtures/variations_xml/abe9721.yml
@@ -6,6 +6,7 @@
     :viewing_direction: left-to-right
     :rights_statement: http://rightsstatements.org/vocab/InC/1.0/
     :visibility: authenticated
+    :viewing_hint: paged
   :local:
     :source_metadata_identifier: ABE9721
     :identifier: http://purl.dlib.indiana.edu/iudl/variations/score/ABE9721

--- a/spec/fixtures/variations_xml/bhr9405.yml
+++ b/spec/fixtures/variations_xml/bhr9405.yml
@@ -6,6 +6,7 @@
     :viewing_direction: left-to-right
     :rights_statement: http://rightsstatements.org/vocab/InC/1.0/
     :visibility: open
+    :viewing_hint: paged
   :local:
     :source_metadata_identifier: BHR9405
     :identifier: http://purl.dlib.indiana.edu/iudl/variations/score/BHR9405

--- a/spec/fixtures/variations_xml/bhr9405.yml
+++ b/spec/fixtures/variations_xml/bhr9405.yml
@@ -4,11 +4,15 @@
   :default:
     :state: final_review
     :viewing_direction: left-to-right
-    :rights_statement: http://rightsstatements.org/vocab/NKC/1.0/
+    :rights_statement: http://rightsstatements.org/vocab/InC/1.0/
     :visibility: open
   :local:
     :source_metadata_identifier: BHR9405
-    :viewing_direction: left-to-right
+    :identifier: http://purl.dlib.indiana.edu/iudl/variations/score/BHR9405
+    :holding_location: https://libraries.indiana.edu/music
+    :physical_description: 1 score (64 p.) ; 32 cm
+    :copyright_holder:
+    - G. Ricordi & Co.
   :remote:
     title:
     - Fontane di Roma ; poema sinfonico per orchestra

--- a/spec/models/variations_document_spec.rb
+++ b/spec/models/variations_document_spec.rb
@@ -8,9 +8,14 @@ RSpec.describe VariationsDocument do
 
   describe "parses attributes" do
     { source_metadata_identifier: 'BHR9405',
+      identifier: 'http://purl.dlib.indiana.edu/iudl/variations/score/BHR9405',
       viewing_direction: 'left-to-right',
       location: 'IU Music Library',
       holding_location: 'https://libraries.indiana.edu/music',
+      physical_description: '1 score (64 p.) ; 32 cm',
+      copyright_holder: ['G. Ricordi & Co.'],
+      visibility: 'open',
+      rights_statement: 'http://rightsstatements.org/vocab/InC/1.0/',
       collections: []
     }.each do |att, val|
       describe "##{att}" do


### PR DESCRIPTION
Adds new Variations-specific fields to preingest, and updates the corresponding fixtures.  As part of this, also adds new properties to the schema, and changes others, and has slight changes to PreingestableDocument to better facilitate variant behavior.