### PR TITLE
[HPT-826] Additional marc fields

### DIFF
--- a/app/jobs/ingest_mets_job.rb
+++ b/app/jobs/ingest_mets_job.rb
@@ -16,11 +16,11 @@ class IngestMETSJob < ActiveJob::Base
 
     def ingest
       resource = minimal_record(@mets.multi_volume? ? MultiVolumeWork : ScannedResource)
-      resource.identifier = @mets.ark_id
+      resource.apply_remote_metadata
       resource.replaces = @mets.pudl_id
       resource.source_metadata_identifier = @mets.bib_id
       resource.member_of_collections = Array(@mets.collection_slugs).map { |slug| find_or_create_collection(slug) }
-      resource.apply_remote_metadata
+      resource.identifier = @mets.ark_id
       resource.save!
       logger.info "Created #{resource.class}: #{resource.id}"
 

--- a/app/models/concerns/common_metadata.rb
+++ b/app/models/concerns/common_metadata.rb
@@ -67,6 +67,7 @@ module CommonMetadata
       end
     end
 
+    # FIXME: change Princeton text, or remove entirely?
     def ezid_metadata
       {
         dc_publisher: 'Princeton University Library',
@@ -76,6 +77,7 @@ module CommonMetadata
       }
     end
 
+    # FIXME: retain, disable, or drop?
     def update_ezid
       Ezid::Identifier.modify(identifier, ezid_metadata)
     end

--- a/app/models/concerns/preingestable_document.rb
+++ b/app/models/concerns/preingestable_document.rb
@@ -7,7 +7,11 @@ module PreingestableDocument
   }
 
   def attributes
-    { default: DEFAULT_ATTRIBUTES, local: local_attributes, remote: remote_attributes }
+    { default: default_attributes, local: local_attributes, remote: remote_attributes }
+  end
+
+  def default_attributes
+    DEFAULT_ATTRIBUTES
   end
 
   def local_attributes

--- a/app/models/concerns/preingestable_document.rb
+++ b/app/models/concerns/preingestable_document.rb
@@ -25,9 +25,15 @@ module PreingestableDocument
   def remote_attributes
     remotes = {}
     remote_data.attributes.each do |k, v|
-      remotes[k] = v.map(&:to_s)
+      if v.class.in? [Array, ActiveTriples::Relation]
+        remotes[k] = v.map(&:value)
+      else
+        remotes[k] = v.value
+      end
     end
-    remotes
+    # remotes
+    # FIXME: choose whether to use attributes above, or raw_attributes below
+    remote_data.raw_attributes
   end
 
   def source_metadata

--- a/app/models/jsonld_record.rb
+++ b/app/models/jsonld_record.rb
@@ -32,27 +32,76 @@ class JSONLDRecord
   def_delegator :@marc, :source, :marc_source
   def_delegator :@mods, :source, :mods_source
 
+  # Runs full transformation pipeline:
+  #
+  # * assigns outbound_graph to proxy_record
+  # * filters proxy_record attributes down to those acquired from outbound_graph
+  # * sets attribute values as RDF::Literal for single values, ActiveTriples::Relation for multiple
+  # * (ActiveTriple relations may have non-deterministic order)
+  #
+  # @return [Hash] RDF attributes for the target factory object
   def attributes
     @attributes ||=
       begin
         Hash[
           cleaned_attributes.map do |k, _|
-            [k, proxy_record.get_values(k, literal: true)]
+            if k.in? singular_fields
+              [k, proxy_record.get_values(k, literal: true).first]
+            else
+              [k, proxy_record.get_values(k, literal: true)]
+            end
           end
         ]
       end
   end
 
-  def appropriate_fields
-    outbound_predicates = outbound_graph.predicates.to_a
-    result = proxy_record.class.properties.select do |_key, value|
-      outbound_predicates.include?(value.predicate)
-    end
-    result.keys
+  # Runs abbreviated transformation pipeline:
+  #
+  # * checks outbound_statements against factory predicates
+  # * sets attribute values simple values for single values, Array for multiple
+  # * (Array values should have a deterministic order)
+  #
+  # @return [Hash] Array, raw-valued attributes for target factory object
+  def raw_attributes
+    @raw_attributes ||=
+      begin
+        raw_hash = {}
+        outbound_statements.each do |s|
+          target_property = outbound_predicates_to_properties[s.predicate]
+          next if target_property.nil?
+          if target_property.in? singular_fields
+            raw_hash[target_property] = s.object.value
+          else
+            raw_hash[target_property] ||= []
+            raw_hash[target_property] << s.object.value
+          end
+        end
+        raw_hash
+      end
   end
 
   private
 
+    CONTEXT = YAML.load(File.read(Rails.root.join('config/context.yml')))
+
+    # used by both pipelines
+    def outbound_statements
+      @outbound_statements ||=
+        begin
+          jsonld_hash = {}
+          jsonld_hash['@context'] = CONTEXT["@context"]
+          jsonld_hash['@id'] = marc.id
+          jsonld_hash.merge!(marc.attributes.stringify_keys)
+          JSON::LD::API.toRdf(jsonld_hash)
+        end
+    end
+
+    # used by full pipeline, only
+    def outbound_graph
+      @outbound_graph ||= RDF::Graph.new << outbound_statements
+    end
+
+    # used by full pipeline, only
     def proxy_record
       @proxy_record ||= factory.new.tap do |resource|
         outbound_graph.each do |statement|
@@ -61,24 +110,30 @@ class JSONLDRecord
       end
     end
 
+    # used by full pipeline, only
+    def appropriate_fields
+      outbound_predicates = outbound_graph.predicates.to_a
+      result = proxy_record.class.properties.select do |_key, value|
+        outbound_predicates.include?(value.predicate)
+      end
+      result.keys
+    end
+
+    # used by both pipelines
+    def singular_fields
+      @singular_fields ||= factory.properties.select { |_att, config| config[:multiple] == false }.keys
+    end
+
+    # used by full pipeline, only
     def cleaned_attributes
       proxy_record.attributes.select do |k, _v|
         appropriate_fields.include?(k)
       end
     end
 
-    def outbound_graph
-      @outbound_graph ||= generate_outbound_graph
-    end
-
-    CONTEXT = YAML.load(File.read(Rails.root.join('config/context.yml')))
-
-    def generate_outbound_graph
-      jsonld_hash = {}
-      jsonld_hash['@context'] = CONTEXT["@context"]
-      jsonld_hash['@id'] = marc.id
-      jsonld_hash.merge!(marc.attributes.stringify_keys)
-      outbound_graph = RDF::Graph.new << JSON::LD::API.toRdf(jsonld_hash)
-      outbound_graph
+    # used by abbreviated pipeline, only
+    def outbound_predicates_to_properties
+      @outbound_predicates_to_properties ||=
+        outbound_statements.predicates.map { |p| [p, factory.properties.detect { |_key, value| value.predicate == p }&.first] }.to_h
     end
 end

--- a/app/models/variations_document.rb
+++ b/app/models/variations_document.rb
@@ -45,14 +45,10 @@ class VariationsDocument
     super.merge(visibility: visibility, rights_statement: rights_statement)
   end
 
-  ATTRIBUTES = [:source_metadata_identifier, :identifier, :holding_location, :media, :copyright_holder]
+  ATTRIBUTES = [:source_metadata_identifier, :holding_location, :media, :copyright_holder]
 
   def local_attributes
     Hash[ATTRIBUTES.map { |att| [att, send(att)] }]
-  end
-
-  def identifier
-    'http://purl.dlib.indiana.edu/iudl/variations/score/' + source_metadata_identifier
   end
 
   def media

--- a/app/models/variations_document.rb
+++ b/app/models/variations_document.rb
@@ -63,7 +63,7 @@ class VariationsDocument
   end
 
   def copyright_holder
-    @variations.xpath("//Container/CopyrightDecls/CopyrightDecl/Owner").first&.content.to_s
+    @variations.xpath("//Container/CopyrightDecls/CopyrightDecl/Owner").map(&:content)
   end
 
   def holding_status

--- a/app/models/variations_document.rb
+++ b/app/models/variations_document.rb
@@ -45,13 +45,10 @@ class VariationsDocument
     super.merge(visibility: visibility, rights_statement: rights_statement)
   end
 
+  ATTRIBUTES = [:source_metadata_identifier, :identifier, :holding_location, :media, :copyright_holder]
+
   def local_attributes
-    { source_metadata_identifier: source_metadata_identifier,
-      identifier: identifier,
-      holding_location: holding_location,
-      media: media,
-      copyright_holder: copyright_holder
-    }
+    Hash[ATTRIBUTES.map { |att| [att, send(att)] }]
   end
 
   def identifier

--- a/app/models/variations_document.rb
+++ b/app/models/variations_document.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ClassLength
 class VariationsDocument
   include PreingestableDocument
   FILE_PATTERN = '*.xml'
@@ -40,10 +41,47 @@ class VariationsDocument
     end
   end
 
+  def default_attributes
+    super.merge(visibility: visibility, rights_statement: rights_statement)
+  end
+
   def local_attributes
     { source_metadata_identifier: source_metadata_identifier,
-      viewing_direction: viewing_direction
+      identifier: identifier,
+      holding_location: holding_location,
+      media: media,
+      copyright_holder: copyright_holder
     }
+  end
+
+  def identifier
+    'http://purl.dlib.indiana.edu/iudl/variations/score/' + source_metadata_identifier
+  end
+
+  def media
+    @variations.xpath("//Container/DocumentInfos/DocumentInfo[Type='Score']/Description").first&.content.to_s
+  end
+
+  def copyright_holder
+    @variations.xpath("//Container/CopyrightDecls/CopyrightDecl/Owner").first&.content.to_s
+  end
+
+  def holding_status
+    @variations.xpath('//Container/HoldingStatus').first&.content.to_s
+  end
+
+  def visibility
+    if holding_status == 'Publicly available'
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    elsif holding_location == 'Personal Collection'
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    else
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+    end
+  end
+
+  def rights_statement
+    'http://rightsstatements.org/vocab/InC/1.0/'
   end
 
   def multi_volume?
@@ -120,3 +158,4 @@ class VariationsDocument
       att_hash
     end
 end
+# rubocop:enable RSpec/DescribeClass

--- a/app/models/vocab/pul_terms.rb
+++ b/app/models/vocab/pul_terms.rb
@@ -6,4 +6,5 @@ class PULTerms < RDF::StrictVocabulary('http://library.princeton.edu/terms/') # 
   term :ocr_language, label: "OCR Language".freeze, type: 'rdf:Property'.freeze
   term :pdf_type, label: "PDF Type".freeze, type: 'rdf:Property'.freeze
   term :call_number, label: "Call Number".freeze, type: 'rdf:Property'.freeze
+  term :published, label: "Published".freeze, type: 'rdf:Property'.freeze
 end

--- a/app/presenters/curation_concerns_show_presenter.rb
+++ b/app/presenters/curation_concerns_show_presenter.rb
@@ -29,12 +29,12 @@ class CurationConcernsShowPresenter < CurationConcerns::WorkShowPresenter
     Array.wrap(solr_document.language).map { |code| LanguageService.label(code) }
   end
 
-  def date_created
-    DateValue.new(solr_document.date_created).to_a
-  end
-
   def page_title
     Array.wrap(title).first
+  end
+
+  def full_title
+    [title, responsibility_note].map { |t| Array.wrap(t).first }.select { |t| !t.blank? }.join(' / ')
   end
 
   def start_canvas

--- a/app/schemas/plum_schema.rb
+++ b/app/schemas/plum_schema.rb
@@ -18,13 +18,17 @@ class PlumSchema < ActiveTriples::Schema
   property :start_canvas, predicate: ::RDF::Vocab::IIIF.hasStartCanvas, multiple: false
 
   # Generated from Context
+  property :edition, predicate: RDF::URI("http://id.loc.gov/ontologies/bibframe/editionStatement")
+  property :series, predicate: RDF::URI("http://id.loc.gov/ontologies/bibframe/seriesStatement")
   property :coverage, predicate: RDF::Vocab::DC11.coverage
+  property :date, predicate: RDF::Vocab::DC11.date
   property :format, predicate: RDF::Vocab::DC11.format
   property :source, predicate: RDF::Vocab::DC11.source
   property :extent, predicate: RDF::Vocab::DC.extent
-  property :edition, predicate: RDF::URI("http://id.loc.gov/ontologies/bibframe/editionStatement")
-  property :series, predicate: RDF::URI("http://id.loc.gov/ontologies/bibframe/seriesStatement")
-  property :call_number, predicate: PULTerms.call_number
+  property :issued, predicate: RDF::Vocab::DC.issued
+  property :modified, predicate: RDF::Vocab::DC.modified
+  property :lccn_call_number, predicate: RDF::Vocab::Identifiers.lccn
+  property :local_call_number, predicate: RDF::Vocab::Identifiers.local
   property :media, predicate: RDF::Vocab::MODS.physicalExtent, multiple: false
   property :abridger, predicate: RDF::Vocab::MARCRelators.abr
   property :actor, predicate: RDF::Vocab::MARCRelators.act
@@ -290,6 +294,9 @@ class PlumSchema < ActiveTriples::Schema
   property :writer_of_supplementary_textual_content, predicate: RDF::Vocab::MARCRelators.wst
   property :writer_of_introduction, predicate: RDF::Vocab::MARCRelators.win
   property :writer_of_preface, predicate: RDF::Vocab::MARCRelators.wpr
+  property :call_number, predicate: PULTerms.call_number
+  property :published, predicate: PULTerms.published, multiple: false
+  property :responsibility_note, predicate: ::RDF::Vocab::SKOS.note
 
   # All of the fields to display when looping through Plum's schema.
   # Ignore things like admin data (workflow note), title, description, etc, as

--- a/app/schemas/plum_schema.rb
+++ b/app/schemas/plum_schema.rb
@@ -11,7 +11,7 @@ class PlumSchema < ActiveTriples::Schema
   property :source_metadata, predicate: ::PULTerms.source_metadata, multiple: false
   property :state, predicate: ::F3Access.objState, multiple: false
   property :workflow_note, predicate: ::RDF::Vocab::MODS.note
-  property :holding_location, predicate: ::RDF::Vocab::Bibframe.heldBy, multiple: false
+  property :holding_location, predicate: RDF::URI("http://id.loc.gov/ontologies/bibframe/heldBy"), multiple: false
   property :ocr_language, predicate: ::PULTerms.ocr_language
   property :nav_date, predicate: ::RDF::URI("http://iiif.io/api/presentation/2#navDate"), multiple: false
   property :pdf_type, predicate: ::PULTerms.pdf_type
@@ -23,7 +23,9 @@ class PlumSchema < ActiveTriples::Schema
   property :source, predicate: RDF::Vocab::DC11.source
   property :extent, predicate: RDF::Vocab::DC.extent
   property :edition, predicate: RDF::URI("http://id.loc.gov/ontologies/bibframe/editionStatement")
+  property :series, predicate: RDF::URI("http://id.loc.gov/ontologies/bibframe/seriesStatement")
   property :call_number, predicate: PULTerms.call_number
+  property :media, predicate: RDF::Vocab::MODS.physicalExtent, multiple: false
   property :abridger, predicate: RDF::Vocab::MARCRelators.abr
   property :actor, predicate: RDF::Vocab::MARCRelators.act
   property :adapter, predicate: RDF::Vocab::MARCRelators.adp
@@ -93,7 +95,7 @@ class PlumSchema < ActiveTriples::Schema
   property :contestee_appellee, predicate: RDF::Vocab::MARCRelators.cte
   property :contractor, predicate: RDF::Vocab::MARCRelators.ctr
   property :copyright_claimant, predicate: RDF::Vocab::MARCRelators.cpc
-  property :copyright_holder, predicate: RDF::Vocab::MARCRelators.cph
+  property :copyright_holder, predicate: RDF::Vocab::MARCRelators.cph, multiple: false
   property :corrector, predicate: RDF::Vocab::MARCRelators.crr
   property :correspondent, predicate: RDF::Vocab::MARCRelators.crp
   property :costume_designer, predicate: RDF::Vocab::MARCRelators.cst

--- a/app/schemas/plum_schema.rb
+++ b/app/schemas/plum_schema.rb
@@ -95,7 +95,7 @@ class PlumSchema < ActiveTriples::Schema
   property :contestee_appellee, predicate: RDF::Vocab::MARCRelators.cte
   property :contractor, predicate: RDF::Vocab::MARCRelators.ctr
   property :copyright_claimant, predicate: RDF::Vocab::MARCRelators.cpc
-  property :copyright_holder, predicate: RDF::Vocab::MARCRelators.cph, multiple: false
+  property :copyright_holder, predicate: RDF::Vocab::MARCRelators.cph
   property :corrector, predicate: RDF::Vocab::MARCRelators.crr
   property :correspondent, predicate: RDF::Vocab::MARCRelators.crp
   property :costume_designer, predicate: RDF::Vocab::MARCRelators.cst

--- a/app/views/curation_concerns/base/_attributes.html.erb
+++ b/app/views/curation_concerns/base/_attributes.html.erb
@@ -4,8 +4,20 @@
     <tr><th>Attribute Name</th><th>Values</th></tr>
   </thead>
   <tbody>
+  <% if @presenter.respond_to?(:full_title) %>
+  <tr>
+    <th>Title</th>
+    <td>
+      <%= @presenter.full_title %>
+    </td>
+  </tr>
+  <% end %>
+  <%= @presenter.attribute_to_html(:series_title) %>
   <%= @presenter.attribute_to_html(:creator, render_as: 'rtl_linked' ) %>
-  <% (PlumSchema.display_fields - [:creator]).each do |display_field| %>
+  <%= @presenter.attribute_to_html(:published) %>
+  <%= @presenter.attribute_to_html(:media) %>
+  <%= @presenter.attribute_to_html(:call_number) %>
+  <% (PlumSchema.display_fields - [:creator, :series_title, :published, :publisher, :publication_place, :issued, :media, :call_number, :identifier]).each do |display_field| %>
     <%= @presenter.attribute_to_html(display_field) %>
   <% end %>
   <tr>

--- a/config/context.yml
+++ b/config/context.yml
@@ -6,11 +6,21 @@
   bf: http://id.loc.gov/ontologies/bibframe/
   dc: http://purl.org/dc/elements/1.1/
   dcterms: http://purl.org/dc/terms/
+  iiif: http://iiif.io/api/presentation/2#
+  loc: http://id.loc.gov/vocabulary/identifiers/
+  om: http://opaquenamespace.org/ns/mods/
   mods: http://www.loc.gov/mods/rdf/v1#
   mrel: http://id.loc.gov/vocabulary/relators/
   pulterms: http://library.princeton.edu/terms/
   rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   rdfs: http://www.w3.org/2000/01/rdf-schema#
+  skos: http://www.w3.org/2004/02/skos/core#
+  edition:
+    "@id": bf:editionStatement
+  holding_location:
+    "@id": bf:heldBy
+  series:
+    "@id": bf:seriesStatement
   contributor:
     "@id": dc:contributor
   coverage:
@@ -23,8 +33,6 @@
     "@id": dc:description
   format:
     "@id": dc:format
-  identifier:
-    "@id": dc:identifier
   language:
     "@id": dc:language
   publisher:
@@ -39,22 +47,28 @@
     "@id": dc:subject
   type:
     "@id": dc:type
-  created:
+  date_created:
     "@id": dcterms:created
   extent:
     "@id": dcterms:extent
+  identifier:
+    "@id": dcterms:identifier
+  issued:
+    "@id": dcterms:issued
   modified:
     "@id": dcterms:modified
+  replaces:
+    "@id": dcterms:replaces
   title:
     "@id": dcterms:title
-  edition:
-    "@id": bf:editionStatement
-  holding_location:
-    "@id": bf:heldBy
-  series:
-    "@id": bf:seriesStatement
-  call_number:
-    "@id": pulterms:call_number
+  viewing_direction:
+    "@id": iiif:viewingDirection
+  lccn_call_number:
+    "@id": loc:lccn
+  local_call_number:
+    "@id": loc:local
+  sort_title:
+    "@id": om:titleForSort
   media:
     "@id": mods:physicalExtent
   abridger:
@@ -587,3 +601,11 @@
     "@id": mrel:win
   writer_of_preface:
     "@id": mrel:wpr
+  call_number:
+    "@id": pulterms:call_number
+  published:
+    "@id": pulterms:published
+  source_metadata_identifier:
+    "@id": pulterms:metadata_id
+  responsibility_note:
+    "@id": skos:note

--- a/config/context.yml
+++ b/config/context.yml
@@ -6,6 +6,7 @@
   bf: http://id.loc.gov/ontologies/bibframe/
   dc: http://purl.org/dc/elements/1.1/
   dcterms: http://purl.org/dc/terms/
+  mods: http://www.loc.gov/mods/rdf/v1#
   mrel: http://id.loc.gov/vocabulary/relators/
   pulterms: http://library.princeton.edu/terms/
   rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
@@ -48,8 +49,14 @@
     "@id": dcterms:title
   edition:
     "@id": bf:editionStatement
+  holding_location:
+    "@id": bf:heldBy
+  series:
+    "@id": bf:seriesStatement
   call_number:
     "@id": pulterms:call_number
+  media:
+    "@id": mods:physicalExtent
   abridger:
     "@id": mrel:abr
   actor:

--- a/lib/iu_metadata/marc_record.rb
+++ b/lib/iu_metadata/marc_record.rb
@@ -8,14 +8,10 @@ module IuMetadata
 
     attr_reader :id, :source
 
+    ATTRIBUTES = [:title, :sort_title, :responsibility_note, :series, :creator, :date_created, :publisher, :publication_place, :issued, :published, :lccn_call_number, :local_call_number]
+
     def attributes
-      {
-        title: title,
-        sort_title: sort_title,
-        creator: creator,
-        date_created: date,
-        publisher: publisher
-      }
+      Hash[ATTRIBUTES.map { |att| [att, send(att)] }]
     end
 
     def abstract
@@ -66,7 +62,7 @@ module IuMetadata
 
     def creator
       creator = []
-      if any_1xx? && !any_7xx_without_t?
+      if any_1xx?
         field = data.fields(['100', '110', '111'])[0]
         creator << format_datafield(field)
         if linked_field?(field)
@@ -74,6 +70,10 @@ module IuMetadata
         end
       end
       creator
+    end
+
+    def date_created
+      Array.wrap(date)
     end
 
     def date
@@ -103,6 +103,10 @@ module IuMetadata
       parts
     end
 
+    def issued
+      formatted_subfields_as_array(['260'], codes: ['c']).map { |s| s.sub(/\s*[:;,]\s*$/, '') }
+    end
+
     def language_codes
       codes = []
       from_fixed = data['008'].value[35, 3]
@@ -121,12 +125,32 @@ module IuMetadata
       codes.uniq
     end
 
+    def lccn_call_number
+      formatted_fields_as_array(['090'], exclude_alpha: ['m'])
+    end
+
+    def local_call_number
+      formatted_fields_as_array(['099'])
+    end
+
     def provenance
       formatted_fields_as_array(['541', '561'])
     end
 
+    def publication_place
+      formatted_subfields_as_array(['260', '264'], codes: ['a']).map { |s| s.sub(/\s*[:;,.]\s*$/, '') }
+    end
+
+    def published
+      formatted_fields_as_array(['260', '264']).first
+    end
+
     def publisher
-      formatted_fields_as_array(['260', '264'], codes: ['b'])
+      formatted_subfields_as_array(['260', '264'], codes: ['b']).map { |s| s.sub(/\s*[:;,.]\s*$/, '') }
+    end
+
+    def responsibility_note
+      formatted_fields_as_array(['245'], codes: ['c'])
     end
 
     def rights
@@ -201,12 +225,9 @@ module IuMetadata
 
     def formatted_fields_as_array(fields, opts = {})
       vals = []
-
       data.fields(fields).each do |field|
         val = format_datafield(field, opts)
-
         vals << val if val != ""
-
         next unless linked_field?(field)
         linked_field = get_linked_field(field)
         val = format_datafield(linked_field, opts)
@@ -215,18 +236,33 @@ module IuMetadata
       vals
     end
 
+    def formatted_subfields_as_array(fields, opts = {})
+      vals = []
+      data.fields(fields).each do |field|
+        val = format_subfields(field, opts)
+        vals += val if val.present?
+        next unless linked_field?(field)
+        linked_field = get_linked_field(field)
+        val = format_subfields(linked_field, opts)
+        vals += val if val.present?
+      end
+      vals
+    end
+
     def format_datafield(datafield, hsh = {})
-      codes = hsh.fetch(:codes, ALPHA)
       separator = hsh.fetch(:separator, ' ')
+      format_subfields(datafield, hsh).join(separator)
+    end
+
+    def format_subfields(datafield, hsh = {})
+      codes = hsh.fetch(:codes, ALPHA).dup
       exclude_alpha = hsh.fetch(:exclude_alpha, [])
-
       exclude_alpha.each { |ex| codes.delete ex }
-
       subfield_values = []
       datafield.select { |sf| codes.include? sf.code }.each do |sf|
         subfield_values << sf.value
       end
-      subfield_values.join(separator)
+      subfield_values
     end
 
     private

--- a/lib/iu_metadata/marc_record.rb
+++ b/lib/iu_metadata/marc_record.rb
@@ -8,7 +8,7 @@ module IuMetadata
 
     attr_reader :id, :source
 
-    ATTRIBUTES = [:title, :sort_title, :responsibility_note, :series, :creator, :date_created, :publisher, :publication_place, :issued, :published, :lccn_call_number, :local_call_number]
+    ATTRIBUTES = [:identifier, :title, :sort_title, :responsibility_note, :series, :creator, :date_created, :publisher, :publication_place, :issued, :published, :lccn_call_number, :local_call_number]
 
     def attributes
       Hash[ATTRIBUTES.map { |att| [att, send(att)] }]
@@ -105,6 +105,10 @@ module IuMetadata
 
     def issued
       formatted_subfields_as_array(['260'], codes: ['c']).map { |s| s.sub(/\s*[:;,]\s*$/, '') }
+    end
+
+    def identifier
+      formatted_subfields_as_array(['856'], codes: ['u']).first
     end
 
     def language_codes

--- a/spec/fixtures/pudl_mets/pudl0001-4609321-s42.yml
+++ b/spec/fixtures/pudl_mets/pudl0001-4609321-s42.yml
@@ -14,10 +14,23 @@
   :remote:
     title:
     - Fontane di Roma ; poema sinfonico per orchestra
+    sort_title: Fontane di Roma ; poema sinfonico per orchestra
+    responsibility_note:
+    - di Ottorino Respighi.
     creator:
     - Respighi, Ottorino, 1879-1936.
+    date_created:
+    - '1947'
     publisher:
-    - G. Ricordi,
+    - G. Ricordi
+    publication_place:
+    - Milano
+    - New York
+    issued:
+    - 1947, c1918.
+    published: 'Milano ; New York : G. Ricordi, 1947, c1918.'
+    lccn_call_number:
+    - M1002.R434 F6, R5, 1947
 :source_metadata: |-
   <record xmlns="http://www.loc.gov/MARC21/slim">
     <!-- Length implementation at offset 22 should hold a digit. Assuming 0 -->

--- a/spec/fixtures/pudl_mets/pudl0001-4609321-s42.yml
+++ b/spec/fixtures/pudl_mets/pudl0001-4609321-s42.yml
@@ -12,6 +12,7 @@
     :source_metadata_identifier: bhr9405
     :viewing_direction: left-to-right
   :remote:
+    identifier: http://purl.dlib.indiana.edu/iudl/variations/score/BHR9405
     title:
     - Fontane di Roma ; poema sinfonico per orchestra
     sort_title: Fontane di Roma ; poema sinfonico per orchestra

--- a/spec/fixtures/pudl_mets/pudl0001-4612596.yml
+++ b/spec/fixtures/pudl_mets/pudl0001-4612596.yml
@@ -14,10 +14,23 @@
   :remote:
     title:
     - Fontane di Roma ; poema sinfonico per orchestra
+    sort_title: Fontane di Roma ; poema sinfonico per orchestra
+    responsibility_note:
+    - di Ottorino Respighi.
     creator:
     - Respighi, Ottorino, 1879-1936.
+    date_created:
+    - '1947'
     publisher:
-    - G. Ricordi,
+    - G. Ricordi
+    publication_place:
+    - Milano
+    - New York
+    issued:
+    - 1947, c1918.
+    published: 'Milano ; New York : G. Ricordi, 1947, c1918.'
+    lccn_call_number:
+    - M1002.R434 F6, R5, 1947
 :source_metadata: |-
   <record xmlns="http://www.loc.gov/MARC21/slim">
     <!-- Length implementation at offset 22 should hold a digit. Assuming 0 -->

--- a/spec/fixtures/pudl_mets/pudl0001-4612596.yml
+++ b/spec/fixtures/pudl_mets/pudl0001-4612596.yml
@@ -12,6 +12,7 @@
     :source_metadata_identifier: bhr9405
     :viewing_direction: left-to-right
   :remote:
+    identifier: http://purl.dlib.indiana.edu/iudl/variations/score/BHR9405
     title:
     - Fontane di Roma ; poema sinfonico per orchestra
     sort_title: Fontane di Roma ; poema sinfonico per orchestra

--- a/spec/fixtures/pudl_mets/pudl0032-ns73.yml
+++ b/spec/fixtures/pudl_mets/pudl0032-ns73.yml
@@ -14,10 +14,23 @@
   :remote:
     title:
     - Fontane di Roma ; poema sinfonico per orchestra
+    sort_title: Fontane di Roma ; poema sinfonico per orchestra
+    responsibility_note:
+    - di Ottorino Respighi.
     creator:
     - Respighi, Ottorino, 1879-1936.
+    date_created:
+    - '1947'
     publisher:
-    - G. Ricordi,
+    - G. Ricordi
+    publication_place:
+    - Milano
+    - New York
+    issued:
+    - 1947, c1918.
+    published: 'Milano ; New York : G. Ricordi, 1947, c1918.'
+    lccn_call_number:
+    - M1002.R434 F6, R5, 1947
 :source_metadata: |-
   <record xmlns="http://www.loc.gov/MARC21/slim">
     <!-- Length implementation at offset 22 should hold a digit. Assuming 0 -->

--- a/spec/fixtures/pudl_mets/pudl0032-ns73.yml
+++ b/spec/fixtures/pudl_mets/pudl0032-ns73.yml
@@ -12,6 +12,7 @@
     :source_metadata_identifier: bhr9405
     :viewing_direction: right-to-left
   :remote:
+    identifier: http://purl.dlib.indiana.edu/iudl/variations/score/BHR9405
     title:
     - Fontane di Roma ; poema sinfonico per orchestra
     sort_title: Fontane di Roma ; poema sinfonico per orchestra

--- a/spec/fixtures/variations_xml/abe9721.yml
+++ b/spec/fixtures/variations_xml/abe9721.yml
@@ -17,8 +17,24 @@
     title:
     - 'The facsimil[e] edition of the autograph of Fryderyk Chopin''s works : from
       the Collection Fryderyk Chopin Society in Warsaw.'
+    sort_title: 'facsimil[e] edition of the autograph of Fryderyk Chopin''s works
+      : from the Collection Fryderyk Chopin Society in Warsaw.'
+    creator:
+    - Chopin, Frédéric, 1810-1849.
+    date_created:
+    - '1990'
     publisher:
-    - Fryderyk Chopin Society ; Green Peace Publishers,
+    - Fryderyk Chopin Society
+    - Green Peace Publishers
+    publication_place:
+    - Warsaw
+    - Tokyo
+    issued:
+    - c1990-
+    published: 'Warsaw : Fryderyk Chopin Society ; Tokyo : Green Peace Publishers,
+      c1990-'
+    lccn_call_number:
+    - ML96.4 .C5
 :source_metadata: |-
   <record xmlns="http://www.loc.gov/MARC21/slim">
     <!-- Length implementation at offset 22 should hold a digit. Assuming 0 -->

--- a/spec/fixtures/variations_xml/abe9721.yml
+++ b/spec/fixtures/variations_xml/abe9721.yml
@@ -4,11 +4,14 @@
   :default:
     :state: final_review
     :viewing_direction: left-to-right
-    :rights_statement: http://rightsstatements.org/vocab/NKC/1.0/
-    :visibility: open
+    :rights_statement: http://rightsstatements.org/vocab/InC/1.0/
+    :visibility: authenticated
   :local:
     :source_metadata_identifier: ABE9721
-    :viewing_direction: left-to-right
+    :identifier: http://purl.dlib.indiana.edu/iudl/variations/score/ABE9721
+    :holding_location: https://libraries.indiana.edu/music
+    :media: "   v. of music : facsims. ; 36 x 44 cm"
+    :copyright_holder: "(C) 1990 Fryderyk Chopin Society; Green Peace Pub."
   :remote:
     title:
     - 'The facsimil[e] edition of the autograph of Fryderyk Chopin''s works : from

--- a/spec/fixtures/variations_xml/abe9721.yml
+++ b/spec/fixtures/variations_xml/abe9721.yml
@@ -11,7 +11,8 @@
     :identifier: http://purl.dlib.indiana.edu/iudl/variations/score/ABE9721
     :holding_location: https://libraries.indiana.edu/music
     :media: "   v. of music : facsims. ; 36 x 44 cm"
-    :copyright_holder: "(C) 1990 Fryderyk Chopin Society; Green Peace Pub."
+    :copyright_holder:
+    - "(C) 1990 Fryderyk Chopin Society; Green Peace Pub."
   :remote:
     title:
     - 'The facsimil[e] edition of the autograph of Fryderyk Chopin''s works : from

--- a/spec/fixtures/variations_xml/abe9721.yml
+++ b/spec/fixtures/variations_xml/abe9721.yml
@@ -8,12 +8,12 @@
     :visibility: authenticated
   :local:
     :source_metadata_identifier: ABE9721
-    :identifier: http://purl.dlib.indiana.edu/iudl/variations/score/ABE9721
     :holding_location: https://libraries.indiana.edu/music
     :media: "   v. of music : facsims. ; 36 x 44 cm"
     :copyright_holder:
     - "(C) 1990 Fryderyk Chopin Society; Green Peace Pub."
   :remote:
+    identifier: http://purl.dlib.indiana.edu/iudl/variations/score/ABE9721
     title:
     - 'The facsimil[e] edition of the autograph of Fryderyk Chopin''s works : from
       the Collection Fryderyk Chopin Society in Warsaw.'

--- a/spec/fixtures/variations_xml/bhr9405.yml
+++ b/spec/fixtures/variations_xml/bhr9405.yml
@@ -4,11 +4,14 @@
   :default:
     :state: final_review
     :viewing_direction: left-to-right
-    :rights_statement: http://rightsstatements.org/vocab/NKC/1.0/
+    :rights_statement: http://rightsstatements.org/vocab/InC/1.0/
     :visibility: open
   :local:
     :source_metadata_identifier: BHR9405
-    :viewing_direction: left-to-right
+    :identifier: http://purl.dlib.indiana.edu/iudl/variations/score/BHR9405
+    :holding_location: https://libraries.indiana.edu/music
+    :media: 1 score (64 p.) ; 32 cm
+    :copyright_holder: G. Ricordi & Co.
   :remote:
     title:
     - Fontane di Roma ; poema sinfonico per orchestra

--- a/spec/fixtures/variations_xml/bhr9405.yml
+++ b/spec/fixtures/variations_xml/bhr9405.yml
@@ -11,7 +11,8 @@
     :identifier: http://purl.dlib.indiana.edu/iudl/variations/score/BHR9405
     :holding_location: https://libraries.indiana.edu/music
     :media: 1 score (64 p.) ; 32 cm
-    :copyright_holder: G. Ricordi & Co.
+    :copyright_holder:
+    - G. Ricordi & Co.
   :remote:
     title:
     - Fontane di Roma ; poema sinfonico per orchestra

--- a/spec/fixtures/variations_xml/bhr9405.yml
+++ b/spec/fixtures/variations_xml/bhr9405.yml
@@ -16,10 +16,23 @@
   :remote:
     title:
     - Fontane di Roma ; poema sinfonico per orchestra
+    sort_title: Fontane di Roma ; poema sinfonico per orchestra
+    responsibility_note:
+    - di Ottorino Respighi.
     creator:
     - Respighi, Ottorino, 1879-1936.
+    date_created:
+    - '1947'
     publisher:
-    - G. Ricordi,
+    - G. Ricordi
+    publication_place:
+    - Milano
+    - New York
+    issued:
+    - 1947, c1918.
+    published: 'Milano ; New York : G. Ricordi, 1947, c1918.'
+    lccn_call_number:
+    - M1002.R434 F6, R5, 1947
 :source_metadata: |-
   <record xmlns="http://www.loc.gov/MARC21/slim">
     <!-- Length implementation at offset 22 should hold a digit. Assuming 0 -->

--- a/spec/fixtures/variations_xml/bhr9405.yml
+++ b/spec/fixtures/variations_xml/bhr9405.yml
@@ -8,12 +8,12 @@
     :visibility: open
   :local:
     :source_metadata_identifier: BHR9405
-    :identifier: http://purl.dlib.indiana.edu/iudl/variations/score/BHR9405
     :holding_location: https://libraries.indiana.edu/music
     :media: 1 score (64 p.) ; 32 cm
     :copyright_holder:
     - G. Ricordi & Co.
   :remote:
+    identifier: http://purl.dlib.indiana.edu/iudl/variations/score/BHR9405
     title:
     - Fontane di Roma ; poema sinfonico per orchestra
     sort_title: Fontane di Roma ; poema sinfonico per orchestra

--- a/spec/iu_metadata/marc_record_spec.rb
+++ b/spec/iu_metadata/marc_record_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe IuMetadata::MarcRecord do
   let(:fixture_path) { File.expand_path('../../fixtures', __FILE__) }
@@ -14,6 +14,20 @@ describe IuMetadata::MarcRecord do
     pth = File.join(fixture_path, '345682.mrx')
     described_class.new(pth, File.open(pth).read)
   }
+  record1_atts =
+     {  title: ['The weeping angels'],
+        sort_title: 'weeping angels',
+        responsibility_note: [],
+        series: [],
+        creator: ['Moffat, Steven.'],
+        date_created: ['1899'],
+        publisher: ['A. Martínez'],
+        publication_place: ['Barceloa'],
+        issued: ['1899.'],
+        published: 'Barceloa, A. Martínez, 1899.',
+        lccn_call_number: [],
+        local_call_number: []
+     }
 
   describe 'id' do
     it 'stores its id' do
@@ -50,14 +64,17 @@ describe IuMetadata::MarcRecord do
 
   describe '#attributes' do
     it 'works' do
-      expected = {
-        title: ['The weeping angels'],
-        sort_title: 'weeping angels',
-        creator: ['Moffat, Steven.'],
-        date_created: '1899',
-        publisher: ['A. Martínez,']
-      }
-      expect(record1.attributes).to eq expected
+      expect(record1.attributes).to eq record1_atts
+    end
+  end
+
+  describe "individual attributes" do
+    record1_atts.each do |att, val|
+      describe "##{att}" do
+        it "returns the expected value" do
+          expect(record1.send(att)).to eq val
+        end
+      end
     end
   end
 

--- a/spec/iu_metadata/marc_record_spec.rb
+++ b/spec/iu_metadata/marc_record_spec.rb
@@ -15,7 +15,8 @@ describe IuMetadata::MarcRecord do
     described_class.new(pth, File.open(pth).read)
   }
   record1_atts =
-     {  title: ['The weeping angels'],
+     {  identifier: nil,
+        title: ['The weeping angels'],
         sort_title: 'weeping angels',
         responsibility_note: [],
         series: [],

--- a/spec/models/scanned_resource_spec.rb
+++ b/spec/models/scanned_resource_spec.rb
@@ -103,8 +103,8 @@ describe ScannedResource do
         expect(subject.title).to eq(['The last resort : a novel'])
         expect(subject.resource.get_values(:title, literal: true)).to eq([RDF::Literal.new('The last resort : a novel')])
         expect(subject.creator).to eq(['Johnson, Pamela Hansford, 1912-1981'])
-        expect(subject.date_created).to eq([])
-        expect(subject.publisher).to eq(["Macmillan & co., ltd., ; St. Martin's Press,"])
+        expect(subject.date_created).to eq(['1956'])
+        expect(subject.publisher.sort).to eq(["St. Martin's Press", "Macmillan & co., ltd.,"].sort)
       end
 
       it 'Saves a record with extacted Voyager metadata' do

--- a/spec/models/variations_document_spec.rb
+++ b/spec/models/variations_document_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe VariationsDocument do
       location: 'IU Music Library',
       holding_location: 'https://libraries.indiana.edu/music',
       media: '1 score (64 p.) ; 32 cm',
-      copyright_holder: 'G. Ricordi & Co.',
+      copyright_holder: ['G. Ricordi & Co.'],
       visibility: 'open',
       rights_statement: 'http://rightsstatements.org/vocab/InC/1.0/',
       collections: []

--- a/spec/models/variations_document_spec.rb
+++ b/spec/models/variations_document_spec.rb
@@ -8,9 +8,14 @@ RSpec.describe VariationsDocument do
   }
   describe "parses attributes" do
     { source_metadata_identifier: 'BHR9405',
+      identifier: 'http://purl.dlib.indiana.edu/iudl/variations/score/BHR9405',
       viewing_direction: 'left-to-right',
       location: 'IU Music Library',
       holding_location: 'https://libraries.indiana.edu/music',
+      media: '1 score (64 p.) ; 32 cm',
+      copyright_holder: 'G. Ricordi & Co.',
+      visibility: 'open',
+      rights_statement: 'http://rightsstatements.org/vocab/InC/1.0/',
       collections: []
     }.each do |att, val|
       describe "##{att}" do

--- a/spec/models/variations_document_spec.rb
+++ b/spec/models/variations_document_spec.rb
@@ -6,9 +6,8 @@ RSpec.describe VariationsDocument do
     pth = File.join(fixture_path, 'variations_xml/bhr9405.xml')
     described_class.new(pth)
   }
-  describe "parses attributes" do
+  record1_attributes =
     { source_metadata_identifier: 'BHR9405',
-      identifier: 'http://purl.dlib.indiana.edu/iudl/variations/score/BHR9405',
       viewing_direction: 'left-to-right',
       location: 'IU Music Library',
       holding_location: 'https://libraries.indiana.edu/music',
@@ -17,7 +16,10 @@ RSpec.describe VariationsDocument do
       visibility: 'open',
       rights_statement: 'http://rightsstatements.org/vocab/InC/1.0/',
       collections: []
-    }.each do |att, val|
+    }
+
+  describe "parses attributes" do
+    record1_attributes.each do |att, val|
       describe "##{att}" do
         it "retrieves the correct value" do
           expect(record1.send(att)).to eq val

--- a/spec/models/vocab/pul_terms_spec.rb
+++ b/spec/models/vocab/pul_terms_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe PULTerms do
       source_metadata: 'Source Metadata',
       ocr_language: 'OCR Language',
       pdf_type: 'PDF Type',
-      call_number: 'Call Number'
+      call_number: 'Call Number',
+      published: 'Published'
     }.each do |term, label|
       describe "#{term}" do
         it "has the right label" do

--- a/spec/presenters/scanned_resource_show_presenter_spec.rb
+++ b/spec/presenters/scanned_resource_show_presenter_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ScannedResourceShowPresenter do
 
   describe "#date_created" do
     it "delegates to solr document" do
-      expect(subject.date_created).to eq ["09/02/2015"]
+      expect(subject.date_created).to eq date_created
     end
   end
   describe "#state" do

--- a/spec/views/curation_concerns/base/_attributes.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/_attributes.html.erb_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "curation_concerns/base/_attributes.html.erb" do
   end
 
   it "displays date created" do
-    expect(rendered).to have_content "09/08/2015"
+    expect(rendered).to have_content date_created
   end
 
   it "displays language name" do


### PR DESCRIPTION
Marking "in progress" because:
 * it merits some discussion, then a couple of changes currently marked with FIXME
 * should probably be rebased after merging existing pull requests

Primarily, this adds new fields into the attribute set that we pull from marcxml, and modifies a few of the existing fields.  However, some additional changes came up as in the process of doing this:
 * Removed date_created from curation_concerns_show_presenter, as it assumed that date_created can be formatted into a Date -- but it's explicitly stated elsewhere that this value is free-form text
 * Slightly refactored some marc_record methods and removed a bug in code inclusion/exclusion logic

The main issue that arose -- and I think it was always present, just not exposed until we were pulling examples of multiple values from a multi-valued field -- is that the remote_data.attributes pipeline has non-deterministic order for a multi-valued field.  This matters for 2 reasons: (1) metadata librarians may want to preserver that order, and (2) it was breaking the tests, as written (which check that preingest generates exactly the expected yaml output string, and swapping two elements in array breaks that match).

In the course of my testing preingest, I found 2 steps of the attributes pipeline that produced non-deterministic ordering:
 1. building the outbound_graph from outbound_statements.  This can actually be side-stepped; in the current code, everything run off of outbound_graph could be run off of outbound_statements, instead.
 2. setting and then retrieving RDF properties from the proxy_record.  If we _want_ to go through this step, I don't see an easy workaround for this problem.
Note that, curiously, when I was running test preingests, on any given run, either BOTH of the aforementioned steps would lose original value order, or NEITHER would.  But I don't know why they seemed to correlate, or why they were nondeterministic.  But overall, the consistent theme seems to be that an RDF graph cannot be guaranteed to return values in the same order that they were assigned -- at least in my local environment.  I don't know to what extent this may be environment-specific.  Also of note is that in my (more-limited) testing of calling #apply_remote_metadata (which uses the full #attributes pipeline) via "refresh metadata" updates in the user interface, or in console, it seemed that value order was retained.

However, the issue can be sidestepped for preingest, by running an abbreviated #raw_attributes pipline that still cross-checks incoming attributes against the target proxy_object type -- but skips the step of actually assigning them and retrieving them from the object.  Arguments for running this route include:
 * it maintains the determinism of preingest, which is nice for testing and also generally
 * it's may be a sufficiently paranaoid preingest validation against the target Model, anyway
But the full #attributes pipeline is still there, and used by #apply_remote_metadata.  So it probably merits discussion whether to retain and use separate remote metadata pipelines for ingest vs "refresh metadata" updates in the interface, or have them both use the same one.

Main questions to resolve:
 * Do we want to retain both the attributes and raw_attributes pipelines?  (We don't have to immediately resolve this, as we can always batch re-run #apply_remote_updates on objects.)
 * Do we want to retain, disable or drop completely the ezid update methods?  (This question probably needs to be resolved sooner, as least in a stopgap fashion, as marking an item "complete" will result in running the ezid update.)

For testing purposes, you can toggle which pipeline preingest uses by toggling whether line 34 or line 36 of app/models/concerns/preingestable_document.rb is commented.  In my experience, re-running preingest off of the #attibutes pipeline was randomly reordering publisher and publication_place fields.
