### PR TITLE
[HPT-923] Fix for Variations preingest filename as pagenum-only

### DIFF
--- a/lib/iu_metadata/variations_record.rb
+++ b/lib/iu_metadata/variations_record.rb
@@ -146,7 +146,13 @@ module IuMetadata
 
       def filename(file_node)
         normalized = file_node.xpath('FileName').first&.content.to_s.downcase.sub(/\.\w{3,4}/, '')
-        root, volume, page = normalized.split('-')
+        if normalized.match /^\d+$/
+          root = source_metadata_identifier.downcase
+          volume = 1
+          page = normalized
+        else
+          root, volume, page = normalized.split('-')
+        end
         "#{root}-#{volume.to_i}-#{page.rjust(4, '0')}.tif"
       end
 

--- a/lib/iu_metadata/variations_record.rb
+++ b/lib/iu_metadata/variations_record.rb
@@ -146,7 +146,7 @@ module IuMetadata
 
       def filename(file_node)
         normalized = file_node.xpath('FileName').first&.content.to_s.downcase.sub(/\.\w{3,4}/, '')
-        if normalized.match /^\d+$/
+        if normalized.match(/^\d+$/)
           root = source_metadata_identifier.downcase
           volume = 1
           page = normalized

--- a/spec/iu_metadata/variations_record_spec.rb
+++ b/spec/iu_metadata/variations_record_spec.rb
@@ -28,6 +28,12 @@ RSpec.describe IuMetadata::VariationsRecord do
   describe "#filename" do
     let(:raw_filename) { file1.xpath('FileName').first&.content.to_s }
     let(:normalized_filename) { record1.send(:filename, file1) }
+    let(:raw_pagenum) { '1.djvu' }
+    let(:pagenum_xml) { "<FileName>#{raw_pagenum}</FileName>" }
+    let(:normalized_pagenum) { record1.send(:filename, Nokogiri::XML(pagenum_xml)) }
+    let(:raw_display) { 'bhr9405-1-1-display.djvu' }
+    let(:display_xml) { "<FileName>#{raw_display}</FileName>" }
+    let(:normalized_display) { record1.send(:filename, Nokogiri::XML(pagenum_xml)) }
     it "normalizes volume, pagenum components" do
       expect(raw_filename).to match(/[a-z]{3}\d{4}-\d{2}-\d{1}/)
       expect(normalized_filename).to match(/[a-z]{3}\d{4}-\d{1}-\d{4}/)
@@ -35,6 +41,14 @@ RSpec.describe IuMetadata::VariationsRecord do
     it "replaces the filename extension" do
       expect(raw_filename).to match(/\.djvu$/)
       expect(normalized_filename).to match(/\.tif$/)
+    end
+    it "normalizes a pagenum-only filename" do
+      expect(raw_pagenum).to match /^\d\.djvu$/
+      expect(normalized_pagenum).to match(/[a-z]{3}\d{4}-\d{1}-\d{4}/)
+    end
+    it "normalizes a display-suffixed filename" do
+      expect(raw_display).to match /display/
+      expect(normalized_display).to match(/^[a-z]{3}\d{4}-\d{1}-\d{4}.tif$/)
     end
   end
 end

--- a/spec/iu_metadata/variations_record_spec.rb
+++ b/spec/iu_metadata/variations_record_spec.rb
@@ -43,11 +43,11 @@ RSpec.describe IuMetadata::VariationsRecord do
       expect(normalized_filename).to match(/\.tif$/)
     end
     it "normalizes a pagenum-only filename" do
-      expect(raw_pagenum).to match /^\d\.djvu$/
+      expect(raw_pagenum).to match(/^\d\.djvu$/)
       expect(normalized_pagenum).to match(/[a-z]{3}\d{4}-\d{1}-\d{4}/)
     end
     it "normalizes a display-suffixed filename" do
-      expect(raw_display).to match /display/
+      expect(raw_display).to match(/display/)
       expect(normalized_display).to match(/^[a-z]{3}\d{4}-\d{1}-\d{4}.tif$/)
     end
   end


### PR DESCRIPTION
Handles Variations preingest case of original filenames listed as "1.djvu", "2.djvu", etc.
Normalizes to standardized bhr9405-1-0001 format.