### PR TITLE
HPT-947 Ingest subject data fields. Trims punctuation from more fields.

### DIFF
--- a/lib/iu_metadata/marc_record.rb
+++ b/lib/iu_metadata/marc_record.rb
@@ -8,7 +8,7 @@ module IuMetadata
 
     attr_reader :id, :source
 
-    ATTRIBUTES = [:identifier, :title, :sort_title, :responsibility_note, :series, :creator, :date_created, :publisher, :publication_place, :issued, :published, :lccn_call_number, :local_call_number]
+    ATTRIBUTES = [:identifier, :title, :sort_title, :responsibility_note, :series, :creator, :subject, :date_created, :publisher, :publication_place, :issued, :published, :lccn_call_number, :local_call_number]
 
     def attributes
       ATTRIBUTES.map { |att| [att, send(att)] }.to_h.compact
@@ -71,7 +71,7 @@ module IuMetadata
           creator << format_datafield(get_linked_field(field))
         end
       end
-      creator
+      trim_punctuation creator
     end
 
     def date_created
@@ -110,7 +110,7 @@ module IuMetadata
     end
 
     def issued
-      formatted_subfields_as_array(['260'], codes: ['c']).map { |s| s.sub(/\s*[:;,]\s*$/, '') }
+      formatted_subfields_as_array(['260'], codes: ['c'])
     end
 
     def language_codes
@@ -144,7 +144,7 @@ module IuMetadata
     end
 
     def publication_place
-      formatted_subfields_as_array(['260', '264'], codes: ['a']).map { |s| s.sub(/\s*[:;,.]\s*$/, '') }
+      formatted_subfields_as_array(['260', '264'], codes: ['a'])
     end
 
     def published
@@ -152,7 +152,7 @@ module IuMetadata
     end
 
     def publisher
-      formatted_subfields_as_array(['260', '264'], codes: ['b']).map { |s| s.sub(/\s*[:;,.]\s*$/, '') }
+      formatted_subfields_as_array(['260', '264'], codes: ['b'])
     end
 
     def responsibility_note
@@ -206,12 +206,12 @@ module IuMetadata
       titles
     end
 
-    def subjects
+    def subject
       # Broken: name puctuation won't come out correctly
       formatted_fields_as_array([
         '600', '610', '611', '630', '648', '650', '651', '653', '654', '655',
         '656', '657', '658', '662', '690'
-      ], separator: '--')
+      ], codes: ['a'])
     end
 
     # We squash together 505s with ' ; '
@@ -239,7 +239,7 @@ module IuMetadata
         val = format_datafield(linked_field, opts)
         vals << val if val != ""
       end
-      vals
+      trim_punctuation(vals)
     end
 
     def formatted_subfields_as_array(fields, opts = {})
@@ -252,7 +252,7 @@ module IuMetadata
         val = format_subfields(linked_field, opts)
         vals += val if val.present?
       end
-      vals
+      trim_punctuation(vals)
     end
 
     def format_datafield(datafield, hsh = {})
@@ -336,6 +336,10 @@ module IuMetadata
           end
         end
         fields
+      end
+
+      def trim_punctuation(ary)
+        ary.map { |s| s.sub(/\s*[:;,.]\s*$/, '') }
       end
   end
 end

--- a/spec/fixtures/pudl_mets/pudl0001-4609321-s42.yml
+++ b/spec/fixtures/pudl_mets/pudl0001-4609321-s42.yml
@@ -17,9 +17,11 @@
     - Fontane di Roma ; poema sinfonico per orchestra
     sort_title: Fontane di Roma ; poema sinfonico per orchestra
     responsibility_note:
-    - di Ottorino Respighi.
+    - di Ottorino Respighi
     creator:
-    - Respighi, Ottorino, 1879-1936.
+    - Respighi, Ottorino, 1879-1936
+    subject:
+        - Symphonic poems
     date_created:
     - '1947'
     publisher:
@@ -28,8 +30,8 @@
     - Milano
     - New York
     issued:
-    - 1947, c1918.
-    published: 'Milano ; New York : G. Ricordi, 1947, c1918.'
+    - 1947, c1918
+    published: 'Milano ; New York : G. Ricordi, 1947, c1918'
     lccn_call_number:
     - M1002.R434 F6, R5, 1947
 :source_metadata: |-

--- a/spec/fixtures/pudl_mets/pudl0001-4612596.yml
+++ b/spec/fixtures/pudl_mets/pudl0001-4612596.yml
@@ -17,9 +17,11 @@
     - Fontane di Roma ; poema sinfonico per orchestra
     sort_title: Fontane di Roma ; poema sinfonico per orchestra
     responsibility_note:
-    - di Ottorino Respighi.
+    - di Ottorino Respighi
     creator:
-    - Respighi, Ottorino, 1879-1936.
+    - Respighi, Ottorino, 1879-1936
+    subject:
+    - Symphonic poems
     date_created:
     - '1947'
     publisher:
@@ -28,8 +30,8 @@
     - Milano
     - New York
     issued:
-    - 1947, c1918.
-    published: 'Milano ; New York : G. Ricordi, 1947, c1918.'
+    - 1947, c1918
+    published: 'Milano ; New York : G. Ricordi, 1947, c1918'
     lccn_call_number:
     - M1002.R434 F6, R5, 1947
 :source_metadata: |-

--- a/spec/fixtures/pudl_mets/pudl0032-ns73.yml
+++ b/spec/fixtures/pudl_mets/pudl0032-ns73.yml
@@ -17,9 +17,11 @@
     - Fontane di Roma ; poema sinfonico per orchestra
     sort_title: Fontane di Roma ; poema sinfonico per orchestra
     responsibility_note:
-    - di Ottorino Respighi.
+    - di Ottorino Respighi
     creator:
-    - Respighi, Ottorino, 1879-1936.
+    - Respighi, Ottorino, 1879-1936
+    subject:
+    - Symphonic poems
     date_created:
     - '1947'
     publisher:
@@ -28,8 +30,8 @@
     - Milano
     - New York
     issued:
-    - 1947, c1918.
-    published: 'Milano ; New York : G. Ricordi, 1947, c1918.'
+    - 1947, c1918
+    published: 'Milano ; New York : G. Ricordi, 1947, c1918'
     lccn_call_number:
     - M1002.R434 F6, R5, 1947
 :source_metadata: |-

--- a/spec/fixtures/variations_xml/abe9721.yml
+++ b/spec/fixtures/variations_xml/abe9721.yml
@@ -20,7 +20,14 @@
     sort_title: 'facsimil[e] edition of the autograph of Fryderyk Chopin''s works
       : from the Collection Fryderyk Chopin Society in Warsaw.'
     creator:
-    - Chopin, Frédéric, 1810-1849.
+    - Chopin, Frédéric, 1810-1849
+    subject:
+    - Piano music
+    - Piano trios
+    - Songs with piano
+    - Sonatas (Cello and piano)
+    - Music
+    - Chopin, Frédéric
     date_created:
     - '1990'
     publisher:

--- a/spec/fixtures/variations_xml/bhr9405.yml
+++ b/spec/fixtures/variations_xml/bhr9405.yml
@@ -18,9 +18,11 @@
     - Fontane di Roma ; poema sinfonico per orchestra
     sort_title: Fontane di Roma ; poema sinfonico per orchestra
     responsibility_note:
-    - di Ottorino Respighi.
+    - di Ottorino Respighi
     creator:
-    - Respighi, Ottorino, 1879-1936.
+    - Respighi, Ottorino, 1879-1936
+    subject:
+    - Symphonic poems
     date_created:
     - '1947'
     publisher:
@@ -29,8 +31,8 @@
     - Milano
     - New York
     issued:
-    - 1947, c1918.
-    published: 'Milano ; New York : G. Ricordi, 1947, c1918.'
+    - 1947, c1918
+    published: 'Milano ; New York : G. Ricordi, 1947, c1918'
     lccn_call_number:
     - M1002.R434 F6, R5, 1947
 :source_metadata: |-

--- a/spec/iu_metadata/marc_record_spec.rb
+++ b/spec/iu_metadata/marc_record_spec.rb
@@ -19,12 +19,13 @@ describe IuMetadata::MarcRecord do
         sort_title: 'weeping angels',
         responsibility_note: [],
         series: [],
-        creator: ['Moffat, Steven.'],
+        creator: ['Moffat, Steven'],
+        subject: ['Cuba'],
         date_created: ['1899'],
         publisher: ['A. Martínez'],
         publication_place: ['Barceloa'],
-        issued: ['1899.'],
-        published: 'Barceloa, A. Martínez, 1899.',
+        issued: ['1899'],
+        published: 'Barceloa, A. Martínez, 1899',
         lccn_call_number: [],
         local_call_number: []
      }
@@ -52,12 +53,12 @@ describe IuMetadata::MarcRecord do
     end
     it 'respects the separator option' do
       fields = ['650']
-      expected = ['International relations.', 'World politics--1985-1995.']
+      expected = ['International relations', 'World politics--1985-1995']
       expect(record3.formatted_fields_as_array(fields, separator: '--')).to eq expected
     end
     it 'respects the codes option' do
       fields = ['650']
-      expected = ['International relations.', 'World politics']
+      expected = ['International relations', 'World politics']
       expect(record3.formatted_fields_as_array(fields, codes: ['a'])).to eq expected
     end
   end
@@ -90,10 +91,10 @@ describe IuMetadata::MarcRecord do
 
   describe '#creator' do
     it 'gets it from the 100' do
-      expect(record1.creator).to eq ['Moffat, Steven.']
+      expect(record1.creator).to eq ['Moffat, Steven']
     end
     it 'includes the 880 version if there is one' do
-      expect(record2.creator).to eq ['Pesin, Aharon Yehoshuʻa.', 'פסין, אהרן יהושע.']
+      expect(record2.creator).to eq ['Pesin, Aharon Yehoshuʻa', 'פסין, אהרן יהושע']
     end
   end
 


### PR DESCRIPTION
HPT-947
Adds subject to the list of fields saved during ingest so they can be presented as facets. Only reads the 'a' subfield based on the implementation in the blacklight-marc gem.
Also moves punctuation trimming to a method and uses it more widely.