### PR TITLE
HPT-928: display metadata on edit page

### DIFF
--- a/app/controllers/curation_concerns/curation_concerns_controller.rb
+++ b/app/controllers/curation_concerns/curation_concerns_controller.rb
@@ -9,6 +9,11 @@ class CurationConcerns::CurationConcernsController < ApplicationController
     curation_concern.class.name.underscore
   end
 
+  def edit
+    presenter
+    super
+  end
+
   def update
     authorize!(:complete, curation_concern, message: 'Unable to mark resource complete') if curation_concern.state != 'complete' && params[curation_concern_name][:state] == 'complete'
     super

--- a/app/presenters/curation_concerns_show_presenter.rb
+++ b/app/presenters/curation_concerns_show_presenter.rb
@@ -37,6 +37,10 @@ class CurationConcernsShowPresenter < CurationConcerns::WorkShowPresenter
     [title, responsibility_note].map { |t| Array.wrap(t).first }.select { |t| !t.blank? }.join(' / ')
   end
 
+  def display_call_number
+    Array.wrap(lccn_call_number.present? ? lccn_call_number : local_call_number).first
+  end
+
   def start_canvas
     Array.wrap(solr_document.start_canvas).first
   end

--- a/app/views/curation_concerns/base/_attributes.html.erb
+++ b/app/views/curation_concerns/base/_attributes.html.erb
@@ -1,8 +1,5 @@
 <table class="table table-striped <%= dom_class(@presenter) %> attributes">
   <caption class="table-heading"><h2>Attributes</h2></caption>
-  <thead>
-    <tr><th>Attribute Name</th><th>Values</th></tr>
-  </thead>
   <tbody>
   <% if @presenter.respond_to?(:full_title) %>
   <tr>
@@ -16,8 +13,15 @@
   <%= @presenter.attribute_to_html(:creator, render_as: 'rtl_linked' ) %>
   <%= @presenter.attribute_to_html(:published) %>
   <%= @presenter.attribute_to_html(:media) %>
-  <%= @presenter.attribute_to_html(:call_number) %>
-  <% (PlumSchema.display_fields - [:creator, :series_title, :published, :publisher, :publication_place, :issued, :media, :call_number, :identifier]).each do |display_field| %>
+  <% if @presenter.try(:display_call_number).present? %>
+  <tr>
+    <th>Call number</th>
+    <td>
+      <%= @presenter.display_call_number %>
+    </td>
+  </tr>
+  <% end %>
+  <% (PlumSchema.display_fields - [:creator, :series_title, :published, :publisher, :publication_place, :issued, :media, :call_number, :identifier, :responsibility_note, :sort_title, :call_number, :lccn_call_number, :local_call_number]).each do |display_field| %>
     <%= @presenter.attribute_to_html(display_field) %>
   <% end %>
   <tr>
@@ -26,7 +30,7 @@
       <%= @presenter.permission_badge %>
     </td>
   </tr>
-  <% if @presenter.respond_to? :state_badge %>
+  <% if @presenter.respond_to?(:state_badge) && can?(:edit, @presenter.id) %>
     <tr>
       <th>State</th>
       <td>
@@ -43,7 +47,6 @@
     <%= @presenter.holding_location %>
   <% end %>
   <%= @presenter.attribute_to_html(:identifier) %>
-  <%= @presenter.attribute_to_html(:source_metadata_identifier) %>
   <%= render 'curation_concerns/base/member_of_collections', presenter: @presenter %>
   <% if can? :edit, @presenter.id %>
     <%= @presenter.attribute_to_html(:workflow_note) %>

--- a/app/views/curation_concerns/base/_attributes_for_editors.html.erb
+++ b/app/views/curation_concerns/base/_attributes_for_editors.html.erb
@@ -1,0 +1,15 @@
+<table class="table table-striped <%= dom_class(@presenter) %> attributes">
+  <caption class="table-heading"><h2>Other Metadata</h2></caption>
+  <tbody>
+  <%= @presenter.attribute_to_html(:series_title) %>
+  <%= @presenter.attribute_to_html(:creator, render_as: 'rtl_linked' ) %>
+  <%= @presenter.attribute_to_html(:published) %>
+  <%= @presenter.attribute_to_html(:media) %>
+  <% (PlumSchema.display_fields - [:creator, :series_title, :published, :media, :call_number, :identifier]).each do |display_field| %>
+    <%= @presenter.attribute_to_html(display_field) %>
+  <% end %>
+  <%= @presenter.attribute_to_html(:embargo_release_date) %>
+  <%= @presenter.attribute_to_html(:lease_expiration_date) %>
+  <%= @presenter.attribute_to_html(:identifier) %>
+  </tbody>
+</table>

--- a/app/views/curation_concerns/base/_form_supplementary_fields.html.erb
+++ b/app/views/curation_concerns/base/_form_supplementary_fields.html.erb
@@ -1,4 +1,4 @@
-<%= render "attributes", presenter: @presenter %>
+<%= render "attributes_for_editors", presenter: @presenter %>
 
 <%= render "form_files_and_links", curation_concern: curation_concern, f: f %>
 

--- a/app/views/curation_concerns/base/_form_supplementary_fields.html.erb
+++ b/app/views/curation_concerns/base/_form_supplementary_fields.html.erb
@@ -1,3 +1,5 @@
+<%= render "attributes", presenter: @presenter %>
+
 <%= render "form_files_and_links", curation_concern: curation_concern, f: f %>
 
 <%= render "form_media", f: f %>


### PR DESCRIPTION
Display a variant of the Attributes table on the Show page, on the Edit page.  (It's tweaked to show some additional fields, but also NOT show fields editable elsewhere on the Edit page.)

This did require modifying the curation concerns controller #edit to load @presenter as for show; we need that for the current approach, but it could later be deprecated if we handle this differently.  Nick said that, long-term, he'd like to display these metadata fields on the Edit page as read-only form inputs, then later make them editable.