### PR TITLE
Ingests work state as 'pending' until completion of job

### DIFF
--- a/spec/jobs/ingest_yaml_job_spec.rb
+++ b/spec/jobs/ingest_yaml_job_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe IngestYAMLJob do
       expect(resource1.title).to eq(["Fontane di Roma ; poema sinfonico per orchestra"])
       expect(resource1.thumbnail_id).to eq('file1')
       expect(resource1.viewing_direction).to eq('left-to-right')
-      expect(resource1.state).to eq('complete')
+      expect(resource1.state).to eq('final_review')
       expect(resource1.visibility).to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
     end
 


### PR DESCRIPTION
This change still pulls the final state (final_review, complete, etc.) from the preingest yaml, but initially sets the work "pending" (Initial digitization, suppressed from display) state, setting the intended final state at the end of the job.

EDIT: Marking this in-progress until we decide (assuming we want this behavior) which way we want to work around the state-change rules preventing jumping from "pending" to anything except the next state, "metadata_review":
- we can force a save, skipping validations (as done in the 2nd commit)
- we can step through all the intermediate states (as done in the 3rd commit)