### PR TITLE
[HPT-942] Show page: added link to view in IUCAT, other tweaks

### DIFF
--- a/app/presenters/curation_concerns_show_presenter.rb
+++ b/app/presenters/curation_concerns_show_presenter.rb
@@ -37,6 +37,10 @@ class CurationConcernsShowPresenter < CurationConcerns::WorkShowPresenter
     [title, responsibility_note].map { |t| Array.wrap(t).first }.select { |t| !t.blank? }.join(' / ')
   end
 
+  def display_call_number
+    Array.wrap(lccn_call_number.present? ? lccn_call_number : local_call_number).first
+  end
+
   def start_canvas
     Array.wrap(solr_document.start_canvas).first
   end

--- a/app/views/curation_concerns/base/_attributes.html.erb
+++ b/app/views/curation_concerns/base/_attributes.html.erb
@@ -1,8 +1,6 @@
+<h2><%= link_to("View record in #{t('services.metadata')}", Plum.config['metadata']['url'] % @presenter.source_metadata_identifier, class: "fa fa-external-link") if @presenter.try(:source_metadata_identifier).present? %></h2>
 <table class="table table-striped <%= dom_class(@presenter) %> attributes">
   <caption class="table-heading"><h2>Attributes</h2></caption>
-  <thead>
-    <tr><th>Attribute Name</th><th>Values</th></tr>
-  </thead>
   <tbody>
   <% if @presenter.respond_to?(:full_title) %>
   <tr>
@@ -16,8 +14,15 @@
   <%= @presenter.attribute_to_html(:creator, render_as: 'rtl_linked' ) %>
   <%= @presenter.attribute_to_html(:published) %>
   <%= @presenter.attribute_to_html(:media) %>
-  <%= @presenter.attribute_to_html(:call_number) %>
-  <% (PlumSchema.display_fields - [:creator, :series_title, :published, :publisher, :publication_place, :issued, :media, :call_number, :identifier]).each do |display_field| %>
+  <% if @presenter.try(:display_call_number).present? %>
+    <tr>
+      <th>Call number</th>
+      <td>
+        <%= @presenter.display_call_number %>
+      </td>
+    </tr>
+  <% end %>
+  <% (PlumSchema.display_fields - [:creator, :series_title, :published, :publisher, :publication_place, :issued, :media, :call_number, :identifier, :responsibility_note, :sort_title, :lccn_call_number, :local_call_number]).each do |display_field| %>
     <%= @presenter.attribute_to_html(display_field) %>
   <% end %>
   <tr>
@@ -26,7 +31,7 @@
       <%= @presenter.permission_badge %>
     </td>
   </tr>
-  <% if @presenter.respond_to? :state_badge %>
+  <% if @presenter.respond_to?(:state_badge) && can?(:edit, @presenter.id) %>
     <tr>
       <th>State</th>
       <td>
@@ -42,10 +47,10 @@
   <% if @presenter.respond_to? :holding_location %>
     <%= @presenter.holding_location %>
   <% end %>
-  <%= @presenter.attribute_to_html(:identifier) %>
-  <%= @presenter.attribute_to_html(:source_metadata_identifier) %>
   <%= render 'curation_concerns/base/member_of_collections', presenter: @presenter %>
   <% if can? :edit, @presenter.id %>
+    <%= @presenter.attribute_to_html(:identifier) %>
+    <%= @presenter.attribute_to_html(:source_metadata_identifier) %>
     <%= @presenter.attribute_to_html(:workflow_note) %>
   <% end %>
   </tbody>

--- a/config/config.yml
+++ b/config/config.yml
@@ -50,6 +50,8 @@ defaults: &defaults
     see_also_hash:
       id: 'http://dlib.indiana.edu:9000/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=%s&recordSchema=marcxml&version=1.1'
       format: 'application/xml'
+  metadata:
+    url: 'https://purl.dlib.indiana.edu/iudl/iucat/%s'
 
 development:
   <<: *defaults

--- a/spec/views/curation_concerns/base/_attributes.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/_attributes.html.erb_spec.rb
@@ -40,10 +40,6 @@ RSpec.describe "curation_concerns/base/_attributes.html.erb" do
     expect(rendered).to have_content 'Baggins'
   end
 
-  it "displays the metadata source id" do
-    expect(rendered).to have_content '8675309'
-  end
-
   it "displays the label for the rights URI" do
     expect(rendered).to have_content "No Known Copyright"
   end


### PR DESCRIPTION
Show page changes:
 * added link to view in IUCAT, call_number display;
 * moved identifier info, state badge into editors-only block;
 * dropped table header row for Attributes