### PR TITLE
[HPT-954] Changed purl controller to redirect to legacy system for invalid IDs

### DIFF
--- a/app/controllers/purl_controller.rb
+++ b/app/controllers/purl_controller.rb
@@ -11,10 +11,10 @@ class PurlController < ApplicationController
     begin
       set_object
       realid = @solr_hit.id
+      url = "#{request.protocol}#{request.host_with_port}#{config.relative_url_root}/concern/#{@subfolder}/#{realid}"
     rescue
-      render_404 && return
+      url = Plum.config['purl_redirect_url'] % params[:id]
     end
-    url = "#{request.protocol}#{request.host_with_port}#{config.relative_url_root}/concern/#{@subfolder}/#{realid}"
     respond_to do |f|
       f.html { redirect_to url }
       f.json { render json: { url: url }.to_json }

--- a/config/config.yml
+++ b/config/config.yml
@@ -6,6 +6,7 @@ defaults: &defaults
   store_original_files: <%= ENV["PMP_STORE_ORIGINAL_FILES"] == 'true' || "true" %>
   master_file_service_url: <%= ENV["PMP_MASTER_FILE_SERVICE_URL"] || "http://purl.dlib.indiana.edu/iudl/variations/master" %>
   access_file_service_url: <%= ENV["PMP_ACCESS_FILE_SERVICE_URL"] || "http://purl.dlib.indiana.edu/iudl/variations/access" %>
+  purl_redirect_url: <%= ENV["PMP_PURL_REDIRECT_URL"] || "http://server1.variations2.indiana.edu/cgi-bin/access?%s" %>
 
   jp2_recipes:
     default_color: >
@@ -52,7 +53,6 @@ defaults: &defaults
       format: 'application/xml'
   metadata:
     url: 'https://purl.dlib.indiana.edu/iudl/iucat/%s'
-  purl_redirect_url: 'http://server1.variations2.indiana.edu/cgi-bin/access?%s'
 
 development:
   <<: *defaults

--- a/config/config.yml
+++ b/config/config.yml
@@ -52,6 +52,7 @@ defaults: &defaults
       format: 'application/xml'
   metadata:
     url: 'https://purl.dlib.indiana.edu/iudl/iucat/%s'
+  purl_redirect_url: 'http://server1.variations2.indiana.edu/cgi-bin/access?%s'
 
 development:
   <<: *defaults


### PR DESCRIPTION
Examples:
 * Old score: http://server1.variations2.indiana.edu/cgi-bin/access?aer3909 
 * Bogus score: http://server1.variations2.indiana.edu/cgi-bin/access?bogus3909 