### PR TITLE
[HPT-962] Improved metadata display for children of MultiVolumeWorks

### DIFF
--- a/app/controllers/purl_controller.rb
+++ b/app/controllers/purl_controller.rb
@@ -1,12 +1,5 @@
 # new class for imago to handle purl redirection
 class PurlController < ApplicationController
-  def render_404
-    respond_to do |f|
-      f.html { render file: '/public/404.html', status: 404 }
-      f.json { render json: { error: 'not_found' }.to_json, status: 404 }
-    end
-  end
-
   def default
     begin
       set_object
@@ -25,8 +18,8 @@ class PurlController < ApplicationController
 
     OBJECT_LOOKUPS = {
       FileSet => /^\w{3}\d{4}-\d{1}-\d{4}$/,
-      ScannedResource => /^\w{3}\d{4}$/,
-      MultiVolumeWork => /^\w{3}\d{4}$/
+      MultiVolumeWork => /^\w{3}\d{4}$/,
+      ScannedResource => /^\w{3}\d{4}$/
     }
     def set_object
       OBJECT_LOOKUPS.each do |klass, match_pattern|

--- a/app/views/curation_concerns/scanned_resources/show.html.erb
+++ b/app/views/curation_concerns/scanned_resources/show.html.erb
@@ -4,10 +4,7 @@
   <% if @parent_presenter %>
     <ul class="breadcrumb">
       <li><%= link_to @parent_presenter, polymorphic_path([main_app, @parent_presenter]) %></li>
-      <li class="active"><%= @presenter.human_readable_type %></li>
     </ul>
-  <% else %>
-    <span class="human_readable_type">(<%= @presenter.human_readable_type %>)</span>
   <% end %>
 <% end %>
 

--- a/lib/tasks/inherit_multivolume_metadata.rake
+++ b/lib/tasks/inherit_multivolume_metadata.rake
@@ -1,0 +1,28 @@
+# Inherit most ingested metadata, exempting identifier, title, and sort_title
+namespace :pmp do
+  desc "Inherit MultiVolumeWork library metadata onto members"
+  task inherit_multivolume_metadata: :environment do |task, args|
+    logger = Logger.new(STDOUT)
+
+    begin
+      parents = MultiVolumeWork.all
+      logger.info "#{parents.size} MultiVolumeWork(s) found"
+      parents.each do |parent|
+        logger.info "Processing MultiVolumeWork: #{parent.id}"
+        children = parent.members
+        logger.info "#{children.size} children found"
+        children.each do |child|
+          logger.info "Processing ScannedResource: #{child.id}"
+          [:source_metadata_identifier, :holding_location, :physical_description, :copyright_holder, :responsibility_note, :series, :creator, :subject, :date_created, :publisher, :publication_place, :issued, :published, :lccn_call_number, :local_call_number].each do |att|
+            child.send("#{att}=", parent.send(att).dup)
+          end
+          child.save!
+        end
+      end
+    rescue => e
+      logger.info "Error: #{e.message}"
+      logger.info e.backtrace
+      abort "Error encountered"
+    end
+  end
+end


### PR DESCRIPTION
Changes:
 * In purl controller:
   * dropped deprecated code (for rendering 404 instead of redirecting to other purl resolver)
   * reordered classes for lookup, so that MultiVolumeWork precedes ScannedResource
* Added rake task to inherit MultiVolumeWork metadata (specified fields) to child works.  In the future, we'll just modify the preingest code, so that the ingest YAML already has them.
* Tweaked the show page view to stop displaying the resource class