### PR TITLE
Full screen universal viewer

### DIFF
--- a/app/assets/stylesheets/components/viewer.scss
+++ b/app/assets/stylesheets/components/viewer.scss
@@ -4,6 +4,14 @@
     position: absolute;
   }
 }
+.fullscreen {
+  position: absolute;
+  height: inherit;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+}
 #viewer-modal {
   .modal-content {
     padding: 20px;

--- a/app/controllers/curation_concerns/scanned_resources_controller.rb
+++ b/app/controllers/curation_concerns/scanned_resources_controller.rb
@@ -19,6 +19,15 @@ class CurationConcerns::ScannedResourcesController < CurationConcerns::CurationC
     CurationConcerns::ScannedResourceForm
   end
 
+  protected
+
+    def additional_response_formats(wants)
+      wants.uv do
+        presenter && parent_presenter
+        render 'viewer_only.html.erb', layout: 'boilerplate', content_type: 'text/html'
+      end
+    end
+
   private
 
     def authorize_pdf

--- a/app/views/curation_concerns/base/_attributes.html.erb
+++ b/app/views/curation_concerns/base/_attributes.html.erb
@@ -1,4 +1,3 @@
-<h2><%= link_to("View record in #{t('services.metadata')}", Plum.config['metadata']['url'] % @presenter.source_metadata_identifier, class: "fa fa-external-link") if @presenter.try(:source_metadata_identifier).present? %></h2>
 <table class="table table-striped <%= dom_class(@presenter) %> attributes">
   <caption class="table-heading"><h2>Attributes</h2></caption>
   <tbody>

--- a/app/views/curation_concerns/base/_misc_links.html.erb
+++ b/app/views/curation_concerns/base/_misc_links.html.erb
@@ -1,0 +1,6 @@
+<h2>
+  <%= link_to("View record in #{t('services.metadata')}",
+                Plum.config['metadata']['url'] % @presenter.source_metadata_identifier, class: "fa fa-external-link"
+        ) if @presenter.try(:source_metadata_identifier).present? %>
+  <%= link_to("Open large viewer", polymorphic_path([main_app, @presenter], format: :uv), class: "fa fa-external-link") %>
+</h2>

--- a/app/views/curation_concerns/base/_representative_media_fullscreen.html.erb
+++ b/app/views/curation_concerns/base/_representative_media_fullscreen.html.erb
@@ -1,0 +1,6 @@
+<% if presenter.respond_to?(:member_presenters) && presenter.member_presenters.present? %>
+  <div class="uv viewer fullscreen" data-config="<%= "#{Rails.application.config.relative_url_root}/uv_config.json" %>" data-uri="<%= main_app.polymorphic_path([main_app,:manifest,presenter]) %>" ></div>
+  <%= UniversalViewer.script_tag %>
+<% else %>
+  <%= image_tag 'nope.png', class: "canonical-image" %>
+<% end %>

--- a/app/views/curation_concerns/scanned_resources/show.html.erb
+++ b/app/views/curation_concerns/scanned_resources/show.html.erb
@@ -15,6 +15,7 @@
 <% editor    = can?(:edit,    @presenter.id) %>
 
 <%= render 'representative_media', presenter: @presenter %>
+<%= render "misc_links", presenter: @presenter %>
 <%= render "attributes", presenter: @presenter %>
 <%= render 'related_files', presenter: @presenter %>
 <%= render "show_actions", collector: collector, editor: editor%>

--- a/app/views/curation_concerns/scanned_resources/viewer_only.html.erb
+++ b/app/views/curation_concerns/scanned_resources/viewer_only.html.erb
@@ -1,0 +1,3 @@
+<% provide :page_title, @presenter.page_title %>
+
+<%= render 'representative_media_fullscreen', presenter: @presenter %>

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -6,3 +6,4 @@ Mime::Type.register "application/n-triples", :nt
 Mime::Type.register "application/ld+json", :jsonld
 Mime::Type.register "text/turtle", :ttl
 Mime::Type.register 'application/x-endnote-refer', :endnote
+Mime::Type.register "application/universalviewer", :uv


### PR DESCRIPTION
Adds a special mime-type and controller response to render a fullscreen version of the CurationConcern#show action. (HPT-957)
Adds a link to this view alongside the IUCAT external link, and moves these links to their own partial. (HPT-958)