### PR TITLE
HPT-964 (Cherry-pick from Plum) Cached manifests (#811)

### DIFF
--- a/app/controllers/concerns/curation_concerns/manifest.rb
+++ b/app/controllers/concerns/curation_concerns/manifest.rb
@@ -35,7 +35,9 @@ module CurationConcerns::Manifest
     end
 
     def manifest_builder
-      PolymorphicManifestBuilder.new(presenter, ssl: request.ssl?)
+      Rails.cache.fetch("manifest/#{presenter.id}/#{ResourceIdentifier.new(presenter.id)}") do
+        PolymorphicManifestBuilder.new(presenter, ssl: request.ssl?).to_json
+      end
     end
 
     def login_url

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -39,10 +39,9 @@ set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/derivatives', 'tmp/up
 namespace :deploy do
   after :restart, :clear_cache do
     on roles(:web), in: :groups, limit: 3, wait: 10 do
-      # Here we can do anything such as:
-      # within release_path do
-      #   execute :rake, 'cache:clear'
-      # end
+      within release_path do
+        execute :rake, 'cache:clear'
+      end
     end
   end
 end

--- a/lib/tasks/clear_cache.rake
+++ b/lib/tasks/clear_cache.rake
@@ -1,0 +1,7 @@
+desc "Clear rails cache"
+namespace :cache do
+  task clear: :environment do
+    puts "Clearing Rails cache"
+    Rails.cache.clear
+  end
+end


### PR DESCRIPTION
* Cache manifests.
* Cache in memcached.
* Clear Rails cache between deploys.
Just in case the manifest generation code changes, don't want to serve
up old versions.

(cherry picked from commit df9753d)