### PR TITLE
HPT-959 Add link to full viewer to search results action button.

### DIFF
--- a/app/views/catalog/_action_menu_partials/_default.html.erb
+++ b/app/views/catalog/_action_menu_partials/_default.html.erb
@@ -1,21 +1,36 @@
-<% if can?(:edit, document) || can?(:collect, document) %>
-  <div class="btn-group">
-    <button class="btn btn-default btn-small dropdown-toggle" data-toggle="dropdown" href="#">Select an action <span class="caret"></span></button>
-    <ul class="dropdown-menu">
-      <% if can? :edit, document %>
-        <li>
-          <%= link_to [:edit, document], class: 'itemicon itemedit' do %><i class="glyphicon glyphicon-pencil"></i> Edit <%= document.human_readable_type %>
-          <% end %>
-        </li>
-        <li>
-          <%= link_to document, class: 'itemicon itemtrash',
-                      title: "Delete #{document.human_readable_type}", method: :delete,
-                      data: {
-                        confirm: "Deleting a #{document.human_readable_type} from #{t('curation_concerns.product_name')} is permanent. Click OK to delete this #{document.human_readable_type} from #{t('curation_concerns.product_name')}, or Cancel to cancel this operation" } do %>
-                          <i class="glyphicon glyphicon-trash"></i> Delete <%= document.human_readable_type %>
-          <% end %>
-        </li>
+<div class="btn-group">
+  <button class="btn btn-default btn-small dropdown-toggle" data-toggle="dropdown" href="#">Select an action <span class="caret"></span></button>
+  <ul class="dropdown-menu">
+    <li>
+      <%= link_to polymorphic_path([main_app, document], format: :uv), class: 'itemicon itemshow' do %>
+          <i class="glyphicon glyphicon-fullscreen"></i> Open in Viewer
       <% end %>
-    </ul>
-  </div>
-<% end %>
+    </li>
+    <% if can? :edit, document %>
+        <li><hr/></li>
+        <li>
+          <%= link_to [:edit, document], class: 'itemicon itemedit' do %>
+              <i class="glyphicon glyphicon-pencil"></i> Edit <%= document.human_readable_type %>
+          <% end %>
+        </li>
+        <li>
+          <%= link_to [:file_manager, document], class: 'itemicon itemedit' do %>
+              <i class="glyphicon glyphicon-file"></i> File Manager
+          <% end %>
+        </li>
+        <li>
+          <%= link_to [:structure, document], class: 'itemicon itemedit' do %>
+              <i class="glyphicon glyphicon-indent-left"></i> Edit Structure
+          <% end %>
+        </li>
+      <li>
+        <%= link_to document, class: 'itemicon itemtrash',
+                    title: "Delete #{document.human_readable_type}", method: :delete,
+                    data: {
+                      confirm: "Deleting a #{document.human_readable_type} from #{t('curation_concerns.product_name')} is permanent. Click OK to delete this #{document.human_readable_type} from #{t('curation_concerns.product_name')}, or Cancel to cancel this operation" } do %>
+                        <i class="glyphicon glyphicon-trash"></i> Delete <%= document.human_readable_type %>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/spec/controllers/curation_concerns/scanned_resources_controller_spec.rb
+++ b/spec/controllers/curation_concerns/scanned_resources_controller_spec.rb
@@ -327,6 +327,26 @@ describe CurationConcerns::ScannedResourcesController do
     end
   end
 
+  describe "show uv format" do
+    before do
+      sign_in user if user
+    end
+    context "when the user is anonymous" do
+      let(:user) { nil }
+
+      context "and the work's complete" do
+        it "works" do
+          resource = FactoryGirl.create(:open_scanned_resource, state: 'complete')
+
+          get :show, id: resource.id, format: :uv
+
+          expect(response).to be_success
+          expect(response).to render_template("viewer_only.html.erb")
+        end
+      end
+    end
+  end
+
   describe 'pdf' do
     before do
       sign_in user if sign_in_user

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -33,6 +33,12 @@ RSpec.feature "CatalogController", type: :feature do
       expect(page).to have_text "Test title"
       expect(page).to have_selector "div.blacklight-state_sim", text: "State"
     end
+
+    scenario "CurationConcerns creators see editing links" do
+      visit search_catalog_path q: ""
+      expect(page).to have_text "Test title"
+      expect(page).to have_selector "a.itemedit", text: "Edit Scanned Resource"
+    end
   end
 
   describe "anonymous user" do
@@ -47,6 +53,12 @@ RSpec.feature "CatalogController", type: :feature do
       visit search_catalog_path q: ""
       expect(page).to have_text "Test title"
       expect(page).not_to have_selector "div.blacklight-state_sim", text: "State"
+    end
+
+    scenario "Anonymous users see a viewer link" do
+      visit search_catalog_path q: ""
+      expect(page).to have_text "Test title"
+      expect(page).to have_selector "a.itemshow", text: "Open in Viewer"
     end
   end
 end


### PR DESCRIPTION
Button will render for all users, but only editors will see the restricted actions.
Also adds direct links to the action button for the File Manager and Structure Editor.
Adds specs to test existence of these links and the full viewer render.