### PR TITLE
Configure UV left panel to show TOC by default.

### DIFF
--- a/public/uv_config.json
+++ b/public/uv_config.json
@@ -1,5 +1,13 @@
 {
   "modules": {
+    "contentLeftPanel" : {
+      "options": {
+        "defaultToTreeEnabled": true
+      },
+      "content": {
+        "index": "TOC"
+      }
+    },
     "footerPanel": {
       "options": {
         "downloadEnabled": false,


### PR DESCRIPTION
Requested by ML. "TOC" label maybe be changed later.