### PR TITLE
Low level retrying of 401 and 500 HTTP errors. 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,6 +98,7 @@ group :test do
   gem "launchy"
   gem "vcr", '~> 2.9'
   gem "webmock", '~> 1.0', require: false
+  gem 'rspecproxies'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -488,7 +488,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    pry-byebug (3.4.0)
+    pry-byebug (3.4.2)
       byebug (~> 9.0)
       pry (~> 0.10)
     pry-rails (0.3.4)
@@ -589,6 +589,8 @@ GEM
     rspec_junit_formatter (0.2.3)
       builder (< 4)
       rspec-core (>= 2, < 4, != 2.12.0)
+    rspecproxies (1.0.0)
+      rspec (~> 3.5)
     rubocop (0.34.2)
       astrolabe (~> 1.3)
       parser (>= 2.2.2.5, < 3.0)
@@ -775,6 +777,7 @@ DEPENDENCIES
   rsolr (~> 1.1.0)
   rspec-rails
   rspec_junit_formatter
+  rspecproxies
   rubocop (~> 0.34.0)
   rubocop-rspec (~> 1.3.0)
   ruby-prof

--- a/config/initializers/faraday.rb
+++ b/config/initializers/faraday.rb
@@ -1,0 +1,74 @@
+Faraday.default_adapter = :net_http_persistent
+
+module Faraday
+  class EssError < Faraday::ClientError; end
+  class EssUnauthorizedError < Faraday::EssError; end
+  class EssServerError < Faraday::EssError; end
+
+  class Response::RaiseEssError < Response::Middleware
+    def on_complete(env)
+      case env[:status]
+      when 400 # Not actually encountered in the wild, but easy to trigger in tests.
+        log_error(env)
+        raise Faraday::EssError, response_values(env)
+      when 401
+        log_error(env)
+        raise Faraday::EssUnauthorizedError, response_values(env)
+      when 500
+        log_error(env)
+        raise Faraday::EssServerError, response_values(env)
+      end
+    end
+
+    private
+
+      def log_error(env)
+        Rails.logger.warn format('Raising HTTP request error for retry: %s %s %s', env[:method], env[:url].to_s, env[:status])
+      end
+
+      def response_values(env)
+        { status: env.status, headers: env.response_headers, body: env.body }
+      end
+  end
+end
+Faraday::Response.register_middleware raise_ess_error: -> { Faraday::Response::RaiseEssError }
+
+module PumpkinExtensions
+  module ActiveFedora
+    module Fedora
+      module FaradayBlock
+        extend ActiveSupport::Concern
+
+        included do
+          def authorized_connection
+            options = {}
+            options[:ssl] = ssl_options if ssl_options
+            connection = Faraday.new(host, options) do |conn|
+              conn.request :url_encoded # This is a default middleware
+              conn.request :retry, max: 4, interval: 0.1, backoff_factor: 4 # Safe retry for timeouts.
+              conn.request :retry, max: 4, interval: 0.1, backoff_factor: 4, # Retry all methods that seem to be ESS errors.
+                                   methods: [], exceptions: ['Faraday::EssError'],
+                                   retry_if: ->(env, _exception) { env[:status] != 404 } # Should never encounter 404, but just in case.
+              conn.request :instrumentation
+              conn.response :raise_ess_error
+              conn.adapter Faraday.default_adapter
+            end
+            connection.basic_auth(user, password)
+            connection
+          end
+        end
+      end
+    end
+  end
+end
+ActiveFedora::Fedora.include PumpkinExtensions::ActiveFedora::Fedora::FaradayBlock
+
+ActiveSupport::Notifications.subscribe('request.faraday') do |_name, starts, ends, _, env|
+  duration = ends - starts
+  if duration > 0.2
+    url = env[:url]
+    http_method = env[:method].to_s.upcase
+    status = env[:status]
+    Rails.logger.info format('Slow request: [%s:%s] %s %s %s (%.3f s)', url.host, url.port, http_method, url.request_uri, status, duration)
+  end
+end

--- a/config/initializers/plum_config.rb
+++ b/config/initializers/plum_config.rb
@@ -17,5 +17,3 @@ module Plum
 end
 
 Hydra::Derivatives.kdu_compress_recipes = Plum.config['jp2_recipes']
-
-Faraday.default_adapter = :net_http_persistent


### PR DESCRIPTION
This includes all methods, regardless of their idempotency! Retries are logged, but the resulting objects are not noted as being a retried object. Not sure how best to interact with a work from the HTTP layer.
Also enables reporting of slow (>200ms) requests.