### PR TITLE
Ingest: adds options for batch (default)/individual/none FileSet membership setting

### DIFF
--- a/app/jobs/ingest_yaml_job.rb
+++ b/app/jobs/ingest_yaml_job.rb
@@ -1,14 +1,18 @@
+# rubocop:disable Metrics/ClassLength
 class IngestYAMLJob < ActiveJob::Base
   include CollectionHelper
+  include CurationConcerns::Lockable
+
   queue_as :ingest
 
   # @param [String] yaml_file Filename of a YAML file to ingest
   # @param [String] user User to ingest as
-  def perform(yaml_file, user)
+  def perform(yaml_file, user, file_association_method: 'batch')
     logger.info "Ingesting YAML #{yaml_file}"
     @yaml_file = yaml_file
     @yaml = File.open(yaml_file) { |f| Psych.load(f) }
     @user = user
+    @file_association_method = file_association_method
     ingest
   end
 
@@ -60,6 +64,7 @@ class IngestYAMLJob < ActiveJob::Base
     end
 
     def ingest_volumes(parent)
+      @volumes = []
       @yaml[:volumes].each do |volume|
         r = ScannedResource.new
         r.attributes = @yaml[:attributes][:default] if @yaml[:attributes].present? && @yaml[:attributes][:default].present?
@@ -73,29 +78,40 @@ class IngestYAMLJob < ActiveJob::Base
         r.logical_order.order = map_fileids(volume[:structure])
         r.state = 'complete'
         r.save!
-
-        parent.ordered_members << r
-        parent.save!
+        @volumes << r
       end
+      parent.ordered_members = @volumes
+      parent.save!
     end
 
     def ingest_files(parent: nil, resource: nil, files: [])
+      @file_sets = []
       files.each do |f|
         logger.info "Ingesting file #{f[:path]}"
         @counter.increment
         file_set = FileSet.new
         file_set.attributes = f[:attributes]
+        copy_visibility(resource, file_set) unless assign_visibility?(f[:attributes])
         actor = FileSetActor.new(file_set, @user)
-        actor.create_metadata(resource, f[:file_opts])
+        if @file_association_method.in? ['batch', 'none']
+          actor.create_metadata(nil, f[:file_opts])
+        else
+          actor.create_metadata(resource, f[:file_opts])
+        end
         actor.create_content(decorated_file(f))
 
         yaml_to_repo_map[f[:id]] = file_set.id
-
-        next unless f[:path] == thumbnail_path
-        resource.thumbnail_id = file_set.id
-        resource.save!
-        parent.thumbnail_id = file_set.id if parent
+        @file_sets << file_set if @file_association_method == 'batch'
+        ingest_thumbnail(file_set, resource, parent) if thumbnail_path?(f[:path])
       end
+      attach_files_to_work(resource, @file_sets) if @file_sets.any?
+    end
+
+    def ingest_thumbnail(file_set, resource, parent)
+      resource.thumbnail_id = file_set.id
+      resource.representative_id = file_set.id
+      parent.thumbnail_id = file_set.id if parent
+      parent.representative_id = file_set.id if parent
     end
 
     def decorated_file(f)
@@ -116,4 +132,52 @@ class IngestYAMLJob < ActiveJob::Base
     def thumbnail_path
       @thumbnail_path ||= @yaml[:thumbnail_path]
     end
+
+    def thumbnail_path?(path)
+      thumbnail_path.present? && thumbnail_path == path
+    end
+
+    # Modified from FileSetActor#attach_file_to_work
+    def attach_files_to_work(work, file_sets)
+      logger.info "Starting batch file_set association on: #{work.id}"
+      acquire_lock_for(work.id) do
+        set_representative(work, file_sets.first)
+        set_thumbnail(work, file_sets.first)
+        # Ensure we have an up-to-date copy of the members association, so
+        # that we append to the end of the list.
+        work.reload unless work.new_record?
+        work.ordered_members = file_sets
+
+        # Save the work so the association between the work and the file_set is persisted (head_id)
+        work.save!
+      end
+      logger.info "Completed batch file_set association"
+      messenger.record_updated(work)
+    end
+
+    # Purloined from FileSetActor, unmodified
+    def assign_visibility?(file_set_params = {})
+      !((file_set_params || {}).keys & %w(visibility embargo_release_date lease_expiration_date)).empty?
+    end
+
+    # copy visibility from source_concern to destination_concern
+    def copy_visibility(source_concern, destination_concern)
+      destination_concern.visibility = source_concern.visibility
+    end
+
+    def set_representative(work, file_set)
+      return unless work.representative_id.blank?
+      work.representative = file_set
+    end
+
+    def set_thumbnail(work, file_set)
+      return unless work.thumbnail_id.blank?
+      work.thumbnail = file_set
+    end
+
+    # Purloined from Plum's FileSetActor, unmodified
+    def messenger
+      @messenger ||= ManifestEventGenerator.new(Plum.messaging_client)
+    end
 end
+# rubocop:enable Metrics/ClassLength

--- a/lib/tasks/ingest_yaml.rake
+++ b/lib/tasks/ingest_yaml.rake
@@ -15,7 +15,9 @@ namespace :pmp do
     logger.info "ingesting as: #{user.user_key} (override with USER=foo)"
 
     begin
-      IngestYAMLJob.perform_now(file, user)
+      file_association_method = ENV['FILE_ASSOCIATION_METHOD'] || 'batch'
+      logger.info "ingesting with file association method: #{file_association_method} (override with FILE_ASSOCIATION_METHOD=batch|individual|none)"
+      IngestYAMLJob.perform_now(file, user, file_association_method: file_association_method)
     rescue => e
       logger.info "Error: #{e.message}"
       logger.info e.backtrace

--- a/spec/jobs/ingest_yaml_job_spec.rb
+++ b/spec/jobs/ingest_yaml_job_spec.rb
@@ -36,62 +36,97 @@ RSpec.describe IngestYAMLJob do
       allow(ingest_counter).to receive(:increment)
     end
 
-    it "recovers from HTTP errors" do
-      allow(actor1).to receive(:attach_related_object)
-      allow(actor1).to receive(:attach_content)
-      allow(actor2).to receive(:create_metadata)
-      allow(actor2).to receive(:create_content)
+    shared_examples "HTTP error recovery" do
+      it "recovers from HTTP errors" do
+        allow(actor1).to receive(:attach_related_object)
+        allow(actor1).to receive(:attach_content)
+        allow(actor2).to receive(:create_metadata)
+        allow(actor2).to receive(:create_content)
 
-      call_count = 0
-      allow_any_instance_of(Net::HTTP).to receive(:transport_request).and_wrap_original { |m, *args, &block|
-        call_count += 1
-        if call_count.odd? && args.first['user-agent'] =~ /^Faraday/ # RSolr does not use Faraday yet.
-          args.first['content-type'] = "BADDATA" # Causes a 400 error in Fedora.
+        call_count = 0
+        allow_any_instance_of(Net::HTTP).to receive(:transport_request).and_wrap_original { |m, *args, &block|
+          call_count += 1
+          if call_count.odd? && args.first['user-agent'] =~ /^Faraday/ # RSolr does not use Faraday yet.
+            args.first['content-type'] = "BADDATA" # Causes a 400 error in Fedora.
+          end
+          m.call(*args, &block)
+        }
+        expect_any_instance_of(Faraday::Request::Retry).to receive(:retry_request?).at_least(:once).and_call_original
+
+        described_class.perform_now(yaml_file_single, user, file_association_method: file_association_method)
+        expect(resource1.state).to eq('complete')
+      end
+    end
+    context "with FILE_ASSOCIATION_METHOD: individual" do
+      let(:file_association_method) { 'individual' }
+      include_examples "HTTP error recovery"
+    end
+    context "with FILE_ASSOCIATION_METHOD: batch" do
+      let(:file_association_method) { 'batch' }
+      include_examples "HTTP error recovery"
+    end
+    context "with FILE_ASSOCIATION_METHOD: none" do
+      let(:file_association_method) { 'none' }
+      include_examples "HTTP error recovery"
+    end
+
+    shared_examples "ingest cases" do
+      it "ingests a single-volume yaml file" do
+        expect(actor1).to receive(:attach_related_object).with(resource1)
+        expect(actor1).to receive(:attach_content).with(instance_of(File))
+        if file_association_method.in? ['batch', 'none']
+          expect(actor2).to receive(:create_metadata).with(nil, {})
+        else
+          expect(actor2).to receive(:create_metadata).with(resource1, {})
         end
-        m.call(*args, &block)
-      }
-      expect_any_instance_of(Faraday::Request::Retry).to receive(:retry_request?).at_least(:once).and_call_original
-
-      described_class.perform_now(yaml_file_single, user)
-      expect(resource1.state).to eq('complete')
+        expect(actor2).to receive(:create_content).with(file)
+        expect(ingest_counter).to receive(:increment)
+        described_class.perform_now(yaml_file_single, user, file_association_method: file_association_method)
+        expect(resource1.title).to eq(["Fontane di Roma ; poema sinfonico per orchestra"])
+        expect(resource1.thumbnail_id).to eq('file1')
+        expect(resource1.viewing_direction).to eq('left-to-right')
+        expect(resource1.state).to eq('complete')
+        expect(resource1.visibility).to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
+      end
+      it "ingests a right-to-left yaml file" do
+        allow(actor1).to receive(:attach_related_object)
+        allow(actor1).to receive(:attach_content)
+        allow(actor2).to receive(:create_metadata)
+        allow(actor2).to receive(:create_content)
+        described_class.perform_now(yaml_file_rtl, user)
+        expect(resource1.viewing_direction).to eq('right-to-left')
+      end
+      it "ingests a multi-volume yaml file" do
+        allow(actor1).to receive(:attach_related_object)
+        allow(actor1).to receive(:attach_content)
+        allow(actor2).to receive(:create_metadata)
+        allow(actor2).to receive(:create_content)
+        expect(resource1).to receive(:logical_order).at_least(:once).and_return(logical_order)
+        expect(resource2).to receive(:logical_order).at_least(:once).and_return(logical_order)
+        expect(logical_order).to receive(:order=).at_least(:once)
+        allow(logical_order).to receive(:order).and_return(nil)
+        allow(logical_order).to receive(:object).and_return(order_object)
+        allow(order_object).to receive(:each_section).and_return([])
+        # kludge exception for batch case
+        if file_association_method == 'batch'
+          allow(work).to receive(:ordered_members=)
+          allow(work).to receive(:ordered_member_ids).and_return(['resource1', 'resource2'])
+        end
+        described_class.perform_now(yaml_file_multi, user, file_association_method: file_association_method)
+        expect(work.ordered_member_ids).to eq(['resource1', 'resource2'])
+      end
     end
-
-    it "ingests a single-volume yaml file" do
-      expect(actor1).to receive(:attach_related_object).with(resource1)
-      expect(actor1).to receive(:attach_content).with(instance_of(File))
-      expect(actor2).to receive(:create_metadata).with(resource1, {})
-      expect(actor2).to receive(:create_content).with(file)
-      expect(ingest_counter).to receive(:increment)
-      described_class.perform_now(yaml_file_single, user)
-      expect(resource1.title).to eq(["Fontane di Roma ; poema sinfonico per orchestra"])
-      expect(resource1.thumbnail_id).to eq('file1')
-      expect(resource1.viewing_direction).to eq('left-to-right')
-      expect(resource1.state).to eq('complete')
-      expect(resource1.visibility).to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
+    context "with FILE_ASSOCIATION_METHOD: individual" do
+      let(:file_association_method) { 'individual' }
+      include_examples "ingest cases"
     end
-
-    it "ingests a right-to-left yaml file" do
-      allow(actor1).to receive(:attach_related_object)
-      allow(actor1).to receive(:attach_content)
-      allow(actor2).to receive(:create_metadata)
-      allow(actor2).to receive(:create_content)
-      described_class.perform_now(yaml_file_rtl, user)
-      expect(resource1.viewing_direction).to eq('right-to-left')
+    context "with FILE_ASSOCIATION_METHOD: batch" do
+      let(:file_association_method) { 'batch' }
+      include_examples "ingest cases"
     end
-
-    it "ingests a multi-volume yaml file" do
-      allow(actor1).to receive(:attach_related_object)
-      allow(actor1).to receive(:attach_content)
-      allow(actor2).to receive(:create_metadata)
-      allow(actor2).to receive(:create_content)
-      expect(resource1).to receive(:logical_order).at_least(:once).and_return(logical_order)
-      expect(resource2).to receive(:logical_order).at_least(:once).and_return(logical_order)
-      expect(logical_order).to receive(:order=).at_least(:once)
-      allow(logical_order).to receive(:order).and_return(nil)
-      allow(logical_order).to receive(:object).and_return(order_object)
-      allow(order_object).to receive(:each_section).and_return([])
-      described_class.perform_now(yaml_file_multi, user)
-      expect(work.ordered_member_ids).to eq(['resource1', 'resource2'])
+    context "with FILE_ASSOCIATION_METHOD: none" do
+      let(:file_association_method) { 'none' }
+      include_examples "ingest cases"
     end
   end
 
@@ -123,7 +158,7 @@ RSpec.describe IngestYAMLJob do
     end
 
     it "ingests a yaml file" do
-      described_class.perform_now(mets_file, user)
+      described_class.perform_now(mets_file, user, file_association_method: 'individual')
       expect(resource.persisted?).to be true
       expect(resource.file_sets.length).to eq 1
       expect(resource.reload.logical_order.order).to eq(order.deep_stringify_keys)


### PR DESCRIPTION
Adds a new ENV setting that the ingest task reads:
```
FILE_ASSOCIATION_METHOD=[batch|individual|none]
```
where:
* _batch_ is new default behavior, that sets ordered membership of FileSets once per ScannedResource, in batch.  This make runtime scale evenly with the size of the score, instead of time-per-page gradually increasing with the number of pages.
* _individual_ is the prior behavior (adding files incrementally)
* _none_ (never associates files to work; builds table of contents structure, only)

This involved copying over code from some other places, which broke the rubocop check on ClassLength for ingest, so I disabled it.  Hopefully this is acceptable for the time being, though longer-term we may want to put the ability to add a batch of files at once somewhere higher up the stack (such as in FileSetActor), or otherwise refactor it to make it more available for the interface to also use for batch file upload.

Also I'm kludging the tests in lines spec/jobs/ingest_yaml_job_spec.rb:112-113 for the batch case -- it produces a 400 error otherwise.  (It'd be better to actually fix it, but I haven't figured out why it's happening.)