### PR TITLE
Bugfix for ingest missing thumbnail

### DIFF
--- a/app/jobs/ingest_yaml_job.rb
+++ b/app/jobs/ingest_yaml_job.rb
@@ -110,6 +110,7 @@ class IngestYAMLJob < ActiveJob::Base
     def ingest_thumbnail(file_set, resource, parent)
       resource.thumbnail_id = file_set.id
       resource.representative_id = file_set.id
+      resource.save!
       parent.thumbnail_id = file_set.id if parent
       parent.representative_id = file_set.id if parent
     end


### PR DESCRIPTION
Added missing resource.save! line for the thumbnail/representative setting to take.  (It's not needed to take for the parent, if applicable.)