### PR TITLE
Experimental: bugfix for structure save in UI?

### DIFF
--- a/app/assets/javascripts/structure_manager.es6
+++ b/app/assets/javascripts/structure_manager.es6
@@ -73,6 +73,8 @@ export default class StructureManager {
       let url = `${root_prefix}/concern/${element.attr("data-class-name")}/${element.attr("data-id")}/structure`
       let button = $(this)
       button.text("Saving..")
+// FIXME: does this prevent the path doubling?
+url = 'structure';
       button.addClass("disabled")
       $.ajax({
         type: "POST",


### PR DESCRIPTION
So I'm experiencing Devon's problem in my local environment, where the Save button flashes change very quickly but does nothing, and the rails log shows:

```
Started POST "/concern/multi_volume_works/dgf06g266n/null/concern/multi_volume_works/dgf06g266n/structure" for 127.0.0.1 at 2017-01-19 16:15:33 -0500

ActionController::RoutingError (No route matches [POST] "/concern/multi_volume_works/dgf06g266n/null/concern/multi_volume_works/dgf06g266n/structure"):
```

so it looks like the route for the work is getting doubled (joined by "null", which I'm guessing is the Rails.application.config.relative_url_root in my case, passed to the javascript method by app/views/curation_concerns/base/structure.html.erb:13).  If I modify the javascript as committed, then it works for me locally.

But this doesn't explain why it would work _sometimes_ for Devon/Nick.  And it probably doesn't generalize if we _do_ need to pass along Rails.application.config.relative_url_root.