### PR TITLE
Bugfix for alphabetize_members failing on nil values

### DIFF
--- a/app/controllers/curation_concerns/curation_concerns_controller.rb
+++ b/app/controllers/curation_concerns/curation_concerns_controller.rb
@@ -15,7 +15,7 @@ class CurationConcerns::CurationConcernsController < ApplicationController
   end
 
   def alphabetize_members
-    @sorted = curation_concern.members.sort { |x, y| x.label <=> y.label }
+    @sorted = curation_concern.members.sort { |x, y| x.label.to_s <=> y.label.to_s }
     flash[:notice] = "Files have been ordered alphabetically, by filename."
     curation_concern.update_attributes(ordered_members: @sorted)
     redirect_to :back


### PR DESCRIPTION
This should fix Devon's problems using the "Sort files alphabetically" button in the File Manager, when it chokes on nil values.  The more interesting thing this exposed is that the FileSets that are causing the issue don't display in the File Manager interface when they belong to the work's members but not the ordered_members.  With this change, running alphabetize_members will include them in ordered_members, and they'll be exposed.  But we might want to consider generally how to catch and fix the situation of a FileSet belonging to members but missing from ordered_members, after cases of failed or incomplete uploads or ingests.