### PR TITLE
[HPT-928] Editable metadata

### DIFF
--- a/app/forms/curation_concerns/multi_volume_work_form.rb
+++ b/app/forms/curation_concerns/multi_volume_work_form.rb
@@ -1,6 +1,6 @@
 module CurationConcerns
   class MultiVolumeWorkForm < ::CurationConcerns::CurationConcernsForm
     self.model_class = ::MultiVolumeWork
-    self.terms += [:viewing_direction, :viewing_hint]
+    self.terms += [:viewing_direction, :viewing_hint, :sort_title, :published, :physical_description, :series, :publication_place, :issued, :lccn_call_number, :local_call_number, :copyright_holder, :responsibility_note]
   end
 end

--- a/app/forms/curation_concerns/scanned_resource_form.rb
+++ b/app/forms/curation_concerns/scanned_resource_form.rb
@@ -1,6 +1,6 @@
 module CurationConcerns
   class ScannedResourceForm < ::CurationConcerns::CurationConcernsForm
     self.model_class = ::ScannedResource
-    self.terms += [:viewing_direction, :viewing_hint]
+    self.terms += [:viewing_direction, :viewing_hint, :sort_title, :published, :physical_description, :series, :publication_place, :issued, :lccn_call_number, :local_call_number, :copyright_holder, :responsibility_note]
   end
 end

--- a/app/models/concerns/common_metadata.rb
+++ b/app/models/concerns/common_metadata.rb
@@ -43,6 +43,12 @@ module CommonMetadata
       ReviewerMailer.notify(id, state).deliver_later
     end
 
+    # override to address issue with @delegated_attributes being in disagreement
+    # with attributes overriden by Schema inclusion
+    def self.multiple?(field)
+      properties[field.to_s].try(:multiple?)
+    end
+
     private
 
     def remote_data

--- a/app/schemas/plum_schema.rb
+++ b/app/schemas/plum_schema.rb
@@ -303,7 +303,11 @@ class PlumSchema < ActiveTriples::Schema
   # Ignore things like admin data (workflow note), title, description, etc, as
   # those have custom display logic.
   def self.display_fields
-    ScannedResource.properties.values.map(&:term) - [:description, :state, :rights_statement, :holding_location, :title, :depositor, :source_metadata_identifier, :source_metadata, :date_modified, :date_uploaded, :workflow_note, :nav_date, :pdf_type, :ocr_language, :keyword, :create_date, :modified_date, :head, :tail] - IIIFBookSchema.properties.map(&:name)
+    ScannedResource.properties.values.map(&:term) - [:description, :state, :rights_statement, :rights_note, :holding_location, :title, :depositor, :source_metadata_identifier, :source_metadata, :date_modified, :date_uploaded, :workflow_note, :nav_date, :pdf_type, :ocr_language, :keyword, :create_date, :modified_date, :head, :tail, :start_canvas] - IIIFBookSchema.properties.map(&:name)
+  end
+
+  def self.edit_fields
+    Plum.config.dig('metadata', 'editable') || PlumSchema.display_fields
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/views/curation_concerns/base/_attributes.html.erb
+++ b/app/views/curation_concerns/base/_attributes.html.erb
@@ -9,10 +9,10 @@
     </td>
   </tr>
   <% end %>
-  <%= @presenter.attribute_to_html(:series_title) %>
+  <%= @presenter.attribute_to_html(:series) %>
   <%= @presenter.attribute_to_html(:creator, render_as: 'rtl_linked' ) %>
   <%= @presenter.attribute_to_html(:published) %>
-  <%= @presenter.attribute_to_html(:media) %>
+  <%= @presenter.attribute_to_html(:physical_description) %>
   <% if @presenter.try(:display_call_number).present? %>
     <tr>
       <th>Call number</th>
@@ -21,7 +21,7 @@
       </td>
     </tr>
   <% end %>
-  <% (PlumSchema.display_fields - [:creator, :series_title, :published, :publisher, :publication_place, :issued, :media, :call_number, :identifier, :responsibility_note, :sort_title, :lccn_call_number, :local_call_number]).each do |display_field| %>
+  <% (PlumSchema.display_fields - [:creator, :series, :published, :publisher, :publication_place, :issued, :physical_description, :call_number, :identifier, :responsibility_note, :sort_title, :lccn_call_number, :local_call_number]).each do |display_field| %>
     <%= @presenter.attribute_to_html(display_field) %>
   <% end %>
   <tr>

--- a/app/views/curation_concerns/base/_form_additional_metadata.html.erb
+++ b/app/views/curation_concerns/base/_form_additional_metadata.html.erb
@@ -1,0 +1,29 @@
+<%# force-drop fields inapplicable, or displayed elsewhere in edit page framework %>
+<% edit_fields = f.object.terms & (PlumSchema.edit_fields - [:has_model, :depositor, :date_uploaded, :date_modified, :relative_path, :import_url, :replaces, :source_metadata, :portion_note, :rights_note, :start_canvas]) %>
+<% single_fields = edit_fields.select { |p| !f.object.model_class.multiple?(p) }.map(&:to_sym) %>
+<% multi_fields = edit_fields - single_fields %>
+<div class="row">
+  <% [{ header: 'Single-valued Metadata Fields',
+        id: 'single-metadata',
+        args: {},
+        fields: single_fields },
+      { header: 'Multi-valued Metadata Fields',
+        id: 'multi-metadata',
+        args: { as: :multi_value },
+        fields: multi_fields }].each do |fieldset| %>
+    <% if fieldset[:fields].any? %>
+      <div class="col-md-6">
+        <fieldset class="optional prompt">
+          <legend><%= fieldset[:header] %></legend>
+          <% fieldset[:fields].each do |display_field| %>
+          <% begin %>
+            <%= f.input display_field, **fieldset[:args] %>
+          <% rescue %>
+            <%= "Error displaying: #{display_field}<br/>".html_safe %>
+          <% end %>
+        <% end %>
+        </fieldset>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/curation_concerns/base/_form_descriptive_fields.html.erb
+++ b/app/views/curation_concerns/base/_form_descriptive_fields.html.erb
@@ -1,0 +1,14 @@
+<div class="row">
+  <div class="col-md-6" id="required-information">
+    <%= render "form_required_information", f: f %>
+  </div>
+
+  <div class="col-md-6" id="additional-information">
+    <%= render "form_additional_information", f: f %>
+  </div>
+</div>
+<div class="row">
+  <div id="additional-metadata">
+    <%= render "form_additional_metadata", f: f %>
+  </div>
+</div>

--- a/config/config.yml
+++ b/config/config.yml
@@ -53,6 +53,22 @@ defaults: &defaults
       format: 'application/xml'
   metadata:
     url: 'https://purl.dlib.indiana.edu/iudl/iucat/%s'
+    editable:
+    - :identifier
+    - :sort_title
+    - :responsibility_note
+    - :series
+    - :creator
+    - :published
+    - :publication_place
+    - :publisher
+    - :issued
+    - :physical_description
+    - :lccn_call_number
+    - :local_call_number
+    - :copyright_holder
+    - :date_created
+    - :subject
 
 development:
   <<: *defaults

--- a/spec/models/multi_volume_work_spec.rb
+++ b/spec/models/multi_volume_work_spec.rb
@@ -92,6 +92,7 @@ describe MultiVolumeWork do
   end
 
   include_examples "structural metadata"
+  include_examples "common metadata"
 
   describe "solr indexing" do
     it "sets number_of_pages by sum of child volumes' pages" do

--- a/spec/models/scanned_resource_spec.rb
+++ b/spec/models/scanned_resource_spec.rb
@@ -226,6 +226,7 @@ describe ScannedResource do
   end
 
   include_examples "structural metadata"
+  include_examples "common metadata"
 
   describe "collection indexing" do
     let(:scanned_resource) { FactoryGirl.create(:scanned_resource_in_collection) }

--- a/spec/support/shared_examples/common_metadata.rb
+++ b/spec/support/shared_examples/common_metadata.rb
@@ -1,0 +1,10 @@
+RSpec.shared_examples "common metadata" do
+  # rubocop:disable RSpec/DescribeClass
+  describe "#identifier" do
+    # rubocop:enable RSpec/DescribeClass
+    # tests workaround for modifying property arity via schema inclusion
+    it "returns false on multiple? check" do
+      expect(subject.class.multiple?(:identifier)).not_to be true
+    end
+  end
+end


### PR DESCRIPTION
This adds a metadata section to edit pages.

The issue I encountered working on this was a problem with checks on single vs multi-valued fields.  The full version is below; the short version is that when Plum overrides a CurationConcerns property with a different arity, it does change in the model, but does _not_ change the results of a multiple? check on the model.  I don't know if we want to file a bug report somewhere up the stack, and where exactly that should go (in apply_schema?), but see the full story below for the details.

Here's the what I found tracing this problem:
* gem: **curation_concerns**
  * in app/controllers/concerns/curation_concerns/curation_concern_controller.rb,
    * [#update ](https://github.com/projecthydra/curation_concerns/blob/master/app/controllers/concerns/curation_concerns/curation_concern_controller.rb#L84-L85) uses:
    * [#attributes_for_actor](https://github.com/projecthydra/curation_concerns/blob/master/app/controllers/concerns/curation_concerns/curation_concern_controller.rb#L174-L177) to get the attribute set for create/update action, which gets its value from the form_class for the curation_concern, in:
* gem: **hydra-editor**
  * In hydra-editor/app/forms/hydra_editor/form.rb, 
    * the [#model_attributes chain](https://github.com/projecthydra/hydra-editor/blob/master/app/forms/hydra_editor/form.rb#L58-L85) depends on
    * the [#multiple? method](https://github.com/projecthydra/hydra-editor/blob/master/app/forms/hydra_editor/form.rb#L48-L50), which is gets its value from
  * [hydra-editor/app/services/hydra_editor/field_metadata_service.rb](https://github.com/projecthydra/hydra-editor/blob/master/app/services/hydra_editor/field_metadata_service.rb), which delegates to the reflection if applicable, or to the model, in:
* gem: **active_fedora**
  * In lib/active_fedora/attributes.rb, 
    * [#multiple?](https://github.com/projecthydra/active_fedora/blob/master/lib/active_fedora/attributes.rb#L111-L114) delegates the lookup to
    * [#delegated_attributes](https://github.com/projecthydra/active_fedora/blob/master/lib/active_fedora/attributes.rb#L90-L95), which has (in some cases) the wrong value set -- and that's as far as I kept looking

What seems to be happening is: in in the cases where the PlumSchema overrides/re-defines a property that's already previously provided (by BasicMetadata), the apply_schema call correctly sets the arity of the property on the model, but does NOT update @delegated_attributes, so they get out of sync.

There are 3 cases where Plum singularizes a property that CurationConcerns sets a multi-valued:
 * description
   * it also changes the RDF predicate from ```::RDF::Vocab::DC11.description``` to ```RDF::Vocab::DC.abstract```
 * identifier
 * rights statement

And one case where it changes single-valued to multi-valued:
 * owner
   * it also _substantially_ changes the RDF predicate from http://opaquenamespace.org/ns/hydra/owner to ```RDF::Vocab::MARCRelators.own```

These disagreements were breaking the ability to view and edit those metadata fields using the form classes.

The workaround this pull request applies is to override the ```.multiple?``` class method in Plum's CommonMetadata module (where the apply_schema calls happen).  The @delegated_attributes values are not changed, so they still hold the wrong value:
```ruby
[24] pry(main)> ScannedResource.delegated_attributes['identifier'].multiple
=> true # uh-oh, that's not right
```
but calling the model method returns the correct one:
```ruby
[25] pry(main)> ScannedResource.multiple?(:identifier)
=> false # yup!
```
and this effectively fixes the stack of calls above it.