### PR TITLE
[HPT-977] Fix MultiVolumeWork page count, volume display

### DIFF
--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -1,3 +1,5 @@
+# rubocop:disable Metrics/CyclomaticComplexity
+# rubocop:disable Metrics/PerceivedComplexity
 class WorkIndexer < CurationConcerns::WorkIndexer
   def generate_solr_document
     super.tap do |solr_doc|
@@ -45,3 +47,5 @@ class WorkIndexer < CurationConcerns::WorkIndexer
       "#{n}-#{n + size - 1} pages"
     end
 end
+# rubocop:enable Metrics/CyclomaticComplexity
+# rubocop:enable Metrics/PerceivedComplexity

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -26,6 +26,9 @@ class WorkIndexer < CurationConcerns::WorkIndexer
       solr_doc[Solrizer.solr_name('sort_title', :stored_sortable)] = object.title.first
 
       pages = object.member_ids.size
+      if object.is_a? MultiVolumeWork
+        pages = object.member_ids.map { |id| ScannedResource.search_with_conditions({ id: id }, rows: 1).first&.dig('number_of_pages_isi').to_i }.reduce(:+)
+      end
       solr_doc[Solrizer.solr_name('number_of_pages', :stored_sortable, type: :integer)] = pages
       solr_doc[Solrizer.solr_name('number_of_pages', :stored_sortable, type: :string)] = pages_bucket(pages, 100)
 

--- a/app/views/curation_concerns/base/_related_files.html.erb
+++ b/app/views/curation_concerns/base/_related_files.html.erb
@@ -1,0 +1,26 @@
+<% if presenter.member_presenters.present? %>
+<div class="panel panel-default related_files">
+  <div class="panel-heading">
+    <h2><%= t('curation_concerns.show.related_files.heading') %></h2>
+  </div>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Thumbnail</th>
+        <th>Title</th>
+        <th>Date Uploaded</th>
+        <th>Visibility</th>
+        <% if presenter.member_presenters.first.model_name.singular.to_sym == :file_set %>
+          <th>Actions</th>
+        <% end %>
+      </tr>
+    </thead>
+    <tbody>
+      <%= render partial: 'member', collection: presenter.member_presenters %>
+    </tbody>
+  </table>
+</div>
+<% elsif can? :edit, presenter.id %>
+  <h2><%= t('curation_concerns.show.related_files.heading') %></h2>
+  <p class="text-center"><em>This <%= presenter.human_readable_type %> has no members associated with it. You can add one using the "Attach a File" button below.</em></p>
+<% end %>

--- a/config/locales/curation_concerns.en.yml
+++ b/config/locales/curation_concerns.en.yml
@@ -14,6 +14,9 @@ en:
       name: *INSTITUTION_NAME
       homepage_url: "#"
     product_name: "Pages Online"
+    show:
+      related_files:
+        heading: Volumes
     visibility:
       authenticated:
         text: *INSTITUTION_NAME

--- a/spec/models/multi_volume_work_spec.rb
+++ b/spec/models/multi_volume_work_spec.rb
@@ -92,4 +92,16 @@ describe MultiVolumeWork do
   end
 
   include_examples "structural metadata"
+
+  describe "solr indexing" do
+    it "sets number_of_pages by sum of child volumes' pages" do
+      scanned_resource1.members = [FactoryGirl.create(:file_set)]
+      scanned_resource1.save
+      scanned_resource2.members = [FactoryGirl.create(:file_set), FactoryGirl.create(:file_set)]
+      scanned_resource2.save
+      subject.ordered_members = [scanned_resource1, scanned_resource2]
+      subject.save
+      expect(subject.to_solr['number_of_pages_isi']).to eq 3
+    end
+  end
 end


### PR DESCRIPTION
**Page count:**
This works, but we might want to handle this differently, immediately or long-term?  Pumpkin and Plum aren't consistently model-agnostic, and while we may need some kind of ScannedResource vs MultiVolumeWork check here, it'd be better to have one that tests multi-volume nature more generally, instead of checking against a particular class.

**Volume display:**
This consists of a configuration change for the section header, and overriding the curation_concerns partial for the table.  Pretty sure we want to do the first (though maybe with a different value?); more on the fence about the second.