### PR TITLE
HPT-1012 OCR configuration

### DIFF
--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -42,12 +42,12 @@ class FileSet < ActiveFedora::Base
           url: derivative_url('intermediate_file')
         ]
       )
-      RunOCRJob.perform_later(id) if Plum.config[:store_original_files]
+      create_ocr(id)
     when mime_type.include?('image/jp2')
       dst = derivative_path('intermediate_file')
       FileUtils.mkdir_p(File.dirname(dst))
       FileUtils.cp(filename, dst)
-      RunOCRJob.perform_later(id) if Plum.config[:store_original_files]
+      create_ocr(id)
     end
     super
   end
@@ -72,6 +72,13 @@ class FileSet < ActiveFedora::Base
 
     def touch_parent_works
       TouchParentJob.perform_later(self)
+    end
+
+    # OCR file if configuration allows
+    #
+    # @param id [String] Fileset id
+    def create_ocr(id)
+      RunOCRJob.perform_later(id) if Plum.config[:create_ocr_files] && Plum.config[:store_original_files]
     end
 
     def ocr_file

--- a/config/config.yml
+++ b/config/config.yml
@@ -7,37 +7,38 @@ defaults: &defaults
   master_file_service_url: <%= ENV["PMP_MASTER_FILE_SERVICE_URL"] || "http://purl.dlib.indiana.edu/iudl/variations/master" %>
   access_file_service_url: <%= ENV["PMP_ACCESS_FILE_SERVICE_URL"] || "http://purl.dlib.indiana.edu/iudl/variations/access" %>
   purl_redirect_url: <%= ENV["PMP_PURL_REDIRECT_URL"] || "http://server1.variations2.indiana.edu/cgi-bin/access?%s" %>
+  create_ocr_files: <%= ENV["PMP_CREATE_OCR_FILES"] || true %>
 
   jp2_recipes:
     default_color: >
-      -rate 2.4,1.48331273,.91673033,.56657224,.35016049,.21641118,.13374944,.08266171 
-      -jp2_space sRGB 
-      -double_buffering 10 
-      -num_threads 1 
-      -no_weights 
-      Clevels=6 
-      Clayers=8 
-      Cblk=\{64,64\} 
-      Cuse_sop=yes 
-      Cuse_eph=yes  
-      Corder=RPCL 
-      ORGgen_plt=yes 
-      ORGtparts=R 
+      -rate 2.4,1.48331273,.91673033,.56657224,.35016049,.21641118,.13374944,.08266171
+      -jp2_space sRGB
+      -double_buffering 10
+      -num_threads 1
+      -no_weights
+      Clevels=6
+      Clayers=8
+      Cblk=\{64,64\}
+      Cuse_sop=yes
+      Cuse_eph=yes
+      Corder=RPCL
+      ORGgen_plt=yes
+      ORGtparts=R
       Stiles=\{1024,1024\}
     default_gray: >
-      -rate 2.4,1.48331273,.91673033,.56657224,.35016049,.21641118,.13374944,.08266171 
-      -jp2_space sLUM 
-      -double_buffering 10 
+      -rate 2.4,1.48331273,.91673033,.56657224,.35016049,.21641118,.13374944,.08266171
+      -jp2_space sLUM
+      -double_buffering 10
       -num_threads 1
-      -no_weights 
-      Clevels=6 
-      Clayers=8 
-      Cblk=\{64,64\} 
-      Cuse_sop=yes 
-      Cuse_eph=yes  
-      Corder=RPCL 
-      ORGgen_plt=yes 
-      ORGtparts=R 
+      -no_weights
+      Clevels=6
+      Clayers=8
+      Cblk=\{64,64\}
+      Cuse_sop=yes
+      Cuse_eph=yes
+      Corder=RPCL
+      ORGgen_plt=yes
+      ORGtparts=R
       Stiles=\{1024,1024\}
   events:
     server: 'amqp://localhost:5672'


### PR DESCRIPTION
This makes it possible to easily disable all OCR-ing of image files. Disabling would be a first when pulling the full text out of an ingest directly.