### PR TITLE
Bugfix for selecting MVW thumbnail via select on Edit page

### DIFF
--- a/app/forms/curation_concerns/multi_volume_work_form.rb
+++ b/app/forms/curation_concerns/multi_volume_work_form.rb
@@ -2,5 +2,19 @@ module CurationConcerns
   class MultiVolumeWorkForm < ::CurationConcerns::CurationConcernsForm
     self.model_class = ::MultiVolumeWork
     self.terms += [:viewing_direction, :viewing_hint, :sort_title, :published, :physical_description, :series, :publication_place, :issued, :lccn_call_number, :local_call_number, :copyright_holder, :responsibility_note]
+
+    # Kludge override of Work version, to get thumbnails to work correctly
+    # @return [Hash] All volumes, volume.to_s is the key, volume.thumbnail_id is the value
+    def select_files
+      Hash[scanned_resource_presenters.map { |volume| [volume.to_s, volume.thumbnail_id] }]
+    end
+
+    private
+
+      # @return [Array<ScannedResourceShowPresenter>] presenters for the member resources
+      def scanned_resource_presenters
+        @scanned_resources ||=
+          PresenterFactory.build_presenters(model.member_ids, ScannedResourceShowPresenter, current_ability)
+      end
   end
 end


### PR DESCRIPTION
`MultiVolumeWorkForm` was inheriting from the standard `CurationConcerns::CorationConcernsForm` a `select_files` method that assumes the model's members are `FileSets`, and accordingly builds and uses `FileSetPresenter` -- this breaks choosing a thumbnail for a multivolume work, because the selected id value is for a ScannedResource.

This fixes the result by:
* building the proper presenter (`ScannedResourceShowPresenter`, rather than `FileSetPresenter`)
* calling `.thumbnail_id`, rather than `.id`, on the presenters