### PR TITLE
Read session store key from env if set.

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,7 +1,7 @@
 # Be sure to restart your server when you modify this file.
 
 if Rails.env == 'production'
-  Rails.application.config.session_store :mem_cache_store, key: '_pages_session'
+  Rails.application.config.session_store :mem_cache_store, key: ENV["RAILS_SESSION_KEY"] || '_pages_session'
 else
-  Rails.application.config.session_store :cookie_store, key: '_pages_session'
+  Rails.application.config.session_store :cookie_store, key: ENV["RAILS_SESSION_KEY"] || '_pages_session'
 end


### PR DESCRIPTION
This is already deployed in Pages and should default to the existing key name if no ENV var is set.