### PR TITLE
[HPT-1013] Add date_published as alternative to date_created

### DIFF
--- a/app/forms/curation_concerns/multi_volume_work_form.rb
+++ b/app/forms/curation_concerns/multi_volume_work_form.rb
@@ -1,7 +1,7 @@
 module CurationConcerns
   class MultiVolumeWorkForm < ::CurationConcerns::CurationConcernsForm
     self.model_class = ::MultiVolumeWork
-    self.terms += [:viewing_direction, :viewing_hint, :sort_title, :published, :physical_description, :series, :publication_place, :issued, :lccn_call_number, :local_call_number, :copyright_holder, :responsibility_note]
+    self.terms += [:viewing_direction, :viewing_hint, :sort_title, :published, :physical_description, :series, :publication_place, :issued, :lccn_call_number, :local_call_number, :copyright_holder, :date_published, :responsibility_note]
 
     # Kludge override of Work version, to get thumbnails to work correctly
     # @return [Hash] All volumes, volume.to_s is the key, volume.thumbnail_id is the value

--- a/app/forms/curation_concerns/scanned_resource_form.rb
+++ b/app/forms/curation_concerns/scanned_resource_form.rb
@@ -1,6 +1,6 @@
 module CurationConcerns
   class ScannedResourceForm < ::CurationConcerns::CurationConcernsForm
     self.model_class = ::ScannedResource
-    self.terms += [:viewing_direction, :viewing_hint, :sort_title, :published, :physical_description, :series, :publication_place, :issued, :lccn_call_number, :local_call_number, :copyright_holder, :responsibility_note]
+    self.terms += [:viewing_direction, :viewing_hint, :sort_title, :published, :physical_description, :series, :publication_place, :issued, :lccn_call_number, :local_call_number, :copyright_holder, :date_published, :responsibility_note]
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -25,6 +25,10 @@ class SolrDocument
     self[Solrizer.solr_name('date_created')]
   end
 
+  def date_published
+    self[Solrizer.solr_name('date_created')]
+  end
+
   def state
     Array(self[Solrizer.solr_name("state")]).first
   end

--- a/app/schemas/plum_schema.rb
+++ b/app/schemas/plum_schema.rb
@@ -23,6 +23,7 @@ class PlumSchema < ActiveTriples::Schema
   property :series, predicate: RDF::URI("http://id.loc.gov/ontologies/bibframe/seriesStatement")
   property :coverage, predicate: RDF::Vocab::DC11.coverage
   property :date, predicate: RDF::Vocab::DC11.date
+  property :date_published, predicate: ::RDF::Vocab::DC.created # duplicate of date_created
   property :format, predicate: RDF::Vocab::DC11.format
   property :source, predicate: RDF::Vocab::DC11.source
   property :extent, predicate: RDF::Vocab::DC.extent
@@ -303,7 +304,7 @@ class PlumSchema < ActiveTriples::Schema
   # Ignore things like admin data (workflow note), title, description, etc, as
   # those have custom display logic.
   def self.display_fields
-    ScannedResource.properties.values.map(&:term) - [:description, :state, :rights_statement, :rights_note, :holding_location, :title, :depositor, :source_metadata_identifier, :source_metadata, :date_modified, :date_uploaded, :workflow_note, :nav_date, :pdf_type, :ocr_language, :keyword, :create_date, :modified_date, :head, :tail, :start_canvas] - IIIFBookSchema.properties.map(&:name)
+    ScannedResource.properties.values.map(&:term) - [:description, :state, :rights_statement, :rights_note, :holding_location, :title, :depositor, :source_metadata_identifier, :source_metadata, :date_modified, :date_uploaded, :workflow_note, :nav_date, :pdf_type, :ocr_language, :keyword, :create_date, :modified_date, :head, :tail, :start_canvas, :date_created] - IIIFBookSchema.properties.map(&:name)
   end
 
   def self.edit_fields

--- a/config/config.yml
+++ b/config/config.yml
@@ -69,7 +69,7 @@ defaults: &defaults
     - :lccn_call_number
     - :local_call_number
     - :copyright_holder
-    - :date_created
+    - :date_published
     - :subject
 
 development:

--- a/config/context.yml
+++ b/config/context.yml
@@ -51,6 +51,8 @@
     "@id": dc:type
   date_created:
     "@id": dcterms:created
+  date_published:
+    "@id": dcterms:created
   extent:
     "@id": dcterms:extent
   identifier:

--- a/spec/views/curation_concerns/base/_attributes.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/_attributes.html.erb_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe "curation_concerns/base/_attributes.html.erb" do
   let(:creator) { 'Bilbo' }
-  let(:date_created) { "2015-09-08" }
+  let(:date_published) { "2015-09-08" }
   let(:rights_statement) { "http://rightsstatements.org/vocab/NKC/1.0/" }
   let(:workflow_note) { ["First", "Second"] }
 
@@ -12,7 +12,7 @@ RSpec.describe "curation_concerns/base/_attributes.html.erb" do
       creator_tesim: creator,
       author_tesim: 'Baggins',
       source_metadata_identifier_tesim: '8675309',
-      date_created_tesim: date_created,
+      date_created_tesim: date_published,
       language_tesim: 'ara',
       rights_statement_tesim: rights_statement,
       workflow_note_tesim: workflow_note
@@ -44,8 +44,8 @@ RSpec.describe "curation_concerns/base/_attributes.html.erb" do
     expect(rendered).to have_content "No Known Copyright"
   end
 
-  it "displays date created" do
-    expect(rendered).to have_content date_created
+  it "displays date published" do
+    expect(rendered).to have_content date_published
   end
 
   it "displays language name" do


### PR DESCRIPTION
Since `date_created` is inherited from `BasicMetadata` in `curation_concerns`, and I didn't want to fiddle with that, I took the approach of adding a duplicate field named `date_published`, pointing it to the same RDF predicate, and modifying a few configurations to make sure `date_published` is exposed in the interface (while `date_created` is hidden).