### PR TITLE
HPT-1155 HPT-1156 Fixing membership and thumbnail bugs for MembershipBuilder

### DIFF
--- a/app/services/membership_builder.rb
+++ b/app/services/membership_builder.rb
@@ -17,9 +17,10 @@ class MembershipBuilder
       # Ensure we have an up-to-date copy of the members association, so
       # that we append to the end of the list.
       work.reload unless work.new_record?
-      work.ordered_members = members
+      members.each do |member|
+        work.ordered_members << member
+      end
       work.save!
-      @members.each(&:update_index)
       messenger.record_updated(work)
     end
   end

--- a/app/services/membership_builder.rb
+++ b/app/services/membership_builder.rb
@@ -12,14 +12,14 @@ class MembershipBuilder
   def attach_files_to_work
     return unless @members.length > 0
     acquire_lock_for(work.id) do
-      set_representative(work, members.first)
-      set_thumbnail(work, members.first)
       # Ensure we have an up-to-date copy of the members association, so
       # that we append to the end of the list.
       work.reload unless work.new_record?
       members.each do |member|
         work.ordered_members << member
       end
+      set_representative(work, members.first)
+      set_thumbnail(work, members.first)
       work.save!
       messenger.record_updated(work)
     end

--- a/spec/services/membership_builder_spec.rb
+++ b/spec/services/membership_builder_spec.rb
@@ -4,12 +4,15 @@ RSpec.describe MembershipBuilder do
   subject { described_class.new(scanned_resource, members) }
   let(:scanned_resource) { FactoryGirl.create(:scanned_resource) }
   let(:members) { [FactoryGirl.create(:file_set), FactoryGirl.create(:file_set), FactoryGirl.create(:file_set)] }
+  let(:appended) { [FactoryGirl.create(:file_set), FactoryGirl.create(:file_set)] }
   let(:reloaded) { scanned_resource.reload }
 
   describe "#attach_files_to_work" do
-    it "appends new file_sets to a work" do
+    it "apppends file_sets to a work" do
       subject.attach_files_to_work
-      expect(reloaded.file_sets.length).to eq 3
+      expect(reloaded.ordered_member_ids.length).to eq 3
+      described_class.new(reloaded, appended).attach_files_to_work
+      expect(reloaded.ordered_member_ids.length).to eq 5
     end
   end
 end

--- a/spec/services/membership_builder_spec.rb
+++ b/spec/services/membership_builder_spec.rb
@@ -14,5 +14,12 @@ RSpec.describe MembershipBuilder do
       described_class.new(reloaded, appended).attach_files_to_work
       expect(reloaded.ordered_member_ids.length).to eq 5
     end
+    it "assigns first member as representative and thumbnail" do
+      subject.attach_files_to_work
+      # Attaching more should not change the initial assignment
+      described_class.new(reloaded, appended).attach_files_to_work
+      expect(reloaded.thumbnail.id).to eq members.first.id
+      expect(reloaded.representative.id).to eq members.first.id
+    end
   end
 end


### PR DESCRIPTION
Fixes:

HPT-1155: Upload from server should append new files but overwrites existing membership
HPT-1156: Upload from server doesn't set representative file_set or thumbnail