### PR TITLE
[HPT-1213] Adds ordered_by_ssim solr field on YML ingest.

### DIFF
--- a/app/services/membership_builder.rb
+++ b/app/services/membership_builder.rb
@@ -17,6 +17,7 @@ class MembershipBuilder
       work.reload unless work.new_record?
       members.each do |member|
         work.ordered_members << member
+        ActiveFedora.solr.conn.add member.to_solr.merge(ordered_by_ssim: [work.id])
       end
       set_representative(work, members.first)
       set_thumbnail(work, members.first)

--- a/spec/services/membership_builder_spec.rb
+++ b/spec/services/membership_builder_spec.rb
@@ -10,8 +10,10 @@ RSpec.describe MembershipBuilder do
   describe "#attach_files_to_work" do
     it "apppends file_sets to a work" do
       subject.attach_files_to_work
+      expect(members.first.to_solr["ordered_by_ssim"]).to eq [scanned_resource.id]
       expect(reloaded.ordered_member_ids.length).to eq 3
       described_class.new(reloaded, appended).attach_files_to_work
+      expect(members.last.to_solr["ordered_by_ssim"]).to eq [scanned_resource.id]
       expect(reloaded.ordered_member_ids.length).to eq 5
     end
     it "assigns first member as representative and thumbnail" do


### PR DESCRIPTION
File sets created during ingest were not getting this field assigned.