### PR TITLE
[HPT-1129] Allow FilePath to clean URIs with spaces

### DIFF
--- a/app/values/file_path.rb
+++ b/app/values/file_path.rb
@@ -1,7 +1,7 @@
 class FilePath
   attr_reader :uri
   def initialize(uri)
-    @uri = uri.to_s
+    @uri = ::URI.encode(uri).to_s
   end
 
   def clean

--- a/spec/values/file_path_spec.rb
+++ b/spec/values/file_path_spec.rb
@@ -1,18 +1,34 @@
 require 'rails_helper'
 
 RSpec.describe FilePath do
+  let(:path_uri) { "file://" + path }
   subject { described_class.new(path_uri) }
-  let(:path_uri) { "file:///bla/test/Test.tiff" }
 
-  describe "#uri" do
-    it "returns the uri" do
-      expect(subject.uri).to eq path_uri
+  shared_examples "object methods succeed" do
+    describe "#uri" do
+      it "returns the encoded uri" do
+        expect(subject.uri).to eq encoded_uri
+      end
+    end
+
+    describe "#clean" do
+      it "returns the URI without the file schema" do
+        expect(subject.clean).to eq clean_path
+      end
     end
   end
 
-  describe "#clean" do
-    it "returns the URI without the file schema" do
-      expect(subject.clean).to eq "/bla/test/Test.tiff"
-    end
+  context "with a plain path" do
+    let(:path) { "/bla/test/Test.tiff" }
+    let(:clean_path) { path }
+    let(:encoded_uri) { path_uri }
+    include_examples "object methods succeed"
+  end
+
+  context "with a path including spaces" do
+    let(:path) { "/bla/test/Test with spaces.tiff" }
+    let(:clean_path) { "/bla/test/Test%20with%20spaces.tiff" }
+    let(:encoded_uri) { "file:///bla/test/Test%20with%20spaces.tiff" }
+    include_examples "object methods succeed"
   end
 end


### PR DESCRIPTION
Resolves bug with spaces in filenames breaking the Upload from Server function in File Manager.