### PR TITLE
HPT-1214 Allows OCR derivatives to be created when store_original_files is false

### DIFF
--- a/app/services/ocr_runner.rb
+++ b/app/services/ocr_runner.rb
@@ -17,6 +17,12 @@ class OCRRunner
     resource.save
   end
 
+  def from_original_file(filename)
+    ocr_output = from_file(filename)
+    attach_ocr(ocr_filename(ocr_output))
+    resource.save
+  end
+
   private
 
     def attach_ocr(filename)


### PR DESCRIPTION
When not storing originals to Fedora (store_original_files = false), the creation of OCR derivatives was not possible because the responsible classes expected to use the stored content object in Fedora as the source.  When not storing files to Fedora, this change ensures that the OCR step can use the original local file in that case.