### PR TITLE
Add OCR indicator to file manager

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -82,6 +82,10 @@ class SolrDocument
     self[Solrizer.solr_name('source_metadata_identifier')]
   end
 
+  def full_text
+    self[Solrizer.solr_name('full_text')]
+  end
+
   def ocr_language
     ocr_lang = self[Solrizer.solr_name('ocr_language')]
     return ocr_lang unless ocr_lang.nil?

--- a/app/presenters/curation_concerns_show_presenter.rb
+++ b/app/presenters/curation_concerns_show_presenter.rb
@@ -1,7 +1,9 @@
 class CurationConcernsShowPresenter < CurationConcerns::WorkShowPresenter
   include ExtraLockable
 
-  delegate :viewing_hint, :viewing_direction, :state, :type, :identifier, :workflow_note, :logical_order, :logical_order_object, :ocr_language, :thumbnail_id, :source_metadata_identifier, :collection, to: :solr_document
+  delegate :viewing_hint, :viewing_direction, :state, :type, :identifier, :workflow_note,
+           :logical_order, :logical_order_object, :ocr_language, :full_text, :thumbnail_id,
+           :source_metadata_identifier, :collection, to: :solr_document
   delegate :flaggable?, to: :state_badge_instance
   delegate(*ScannedResource.properties.values.map(&:term), to: :solr_document, allow_nil: true)
   delegate(*ScannedResource.properties.values.map { |x| "#{x.term}_literals" }, to: :solr_document, allow_nil: true)

--- a/app/presenters/file_set_presenter.rb
+++ b/app/presenters/file_set_presenter.rb
@@ -1,6 +1,6 @@
 class FileSetPresenter < CurationConcerns::FileSetPresenter
   include CurationConcerns::Serializers
-  delegate :viewing_hint, :title, :file_label, :width, :height, to: :solr_document
+  delegate :viewing_hint, :title, :file_label, :width, :height, :full_text, to: :solr_document
 
   def thumbnail_id
     id

--- a/app/views/curation_concerns/base/_file_manager_attributes.html.erb
+++ b/app/views/curation_concerns/base/_file_manager_attributes.html.erb
@@ -1,3 +1,5 @@
+<p>OCR: <%= node.full_text ? '✓' : nil %></p>
+
 <% if node.model_name.singular == "file_set" %>
   <%= f.input :viewing_hint, collection: [:"", :"non-paged", :"facing-pages"], as: :radio_buttons, label: false, defaults: { input_html: { class: '' }}%>
 <% end %>

--- a/spec/views/curation_concerns/base/file_manager.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/file_manager.html.erb_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe "curation_concerns/base/file_manager.html.erb" do
         id: "test",
         title_tesim: ["Test"],
         thumbnail_path_ss: "/test/image/path.jpg",
-        label_tesim: ["file_name.tif"]
+        label_tesim: ["file_name.tif"],
+        full_text_tesim: ["This is some text"]
       )
     )
   end
@@ -113,6 +114,10 @@ RSpec.describe "curation_concerns/base/file_manager.html.erb" do
 
   it "renders an input for titles" do
     expect(rendered).to have_selector("input[name='file_set[title][]']")
+  end
+
+  it "renders an OCR checkmark" do
+    expect(rendered).to have_content("OCR: ✓")
   end
 
   it "has radio inputs for viewing hints" do


### PR DESCRIPTION
A checkmark is displayed based on the assumption that an OCR file exists if the full_text_tesim solr field is populated.