### PR TITLE
[HPT-1243] Re-enable Performance rules and fix offenses.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -170,15 +170,6 @@ Naming/FileName:
 Naming/VariableNumber:
   Enabled: true
 
-Performance/HashEachMethods:
-  Enabled: false
-
-Performance/RedundantBlockCall:
-  Enabled: false
-
-Performance/RedundantMatch:
-  Enabled: false
-
 Rails/ApplicationJob:
   Enabled: false
 

--- a/app/helpers/osd_modal_helper.rb
+++ b/app/helpers/osd_modal_helper.rb
@@ -1,7 +1,7 @@
 module OsdModalHelper
   def osd_modal_for(id, &block)
     if !id
-      block.call
+      block.call # rubocop:disable Performance/RedundantBlockCall
     else
       content_tag :span, class: 'ignore-select', data: { modal_manifest: "#{IIIFPath.new(id)}/info.json" }, &block
     end

--- a/app/jobs/ingest_yaml_job.rb
+++ b/app/jobs/ingest_yaml_job.rb
@@ -22,7 +22,7 @@ class IngestYAMLJob < ActiveJob::Base
       @counter = IngestCounter.new
       resource = (@yaml[:volumes].present? ? MultiVolumeWork : ScannedResource).new
       if @yaml[:attributes].present?
-        @yaml[:attributes].each { |_set_name, attributes| resource.attributes = attributes }
+        @yaml[:attributes].each_value { |attributes| resource.attributes = attributes }
       end
       resource.source_metadata = @yaml[:source_metadata] if @yaml[:source_metadata].present?
 

--- a/app/models/composite_pending_upload.rb
+++ b/app/models/composite_pending_upload.rb
@@ -1,6 +1,6 @@
 class CompositePendingUpload
   def self.create(params, curation_concern_id, upload_set_id)
-    params.each do |_index, file_options|
+    params.each_value do |file_options|
       new(file_options, curation_concern_id, upload_set_id).save
     end
   end

--- a/app/services/word_boundaries_runner.rb
+++ b/app/services/word_boundaries_runner.rb
@@ -54,13 +54,13 @@ class WordBoundariesRunner
       parts.each do |part|
         sections = part.split(' ')
         sections.shift
-        if /^bbox/.match(part)
+        if /^bbox/ =~ part
           x0, y0, x1, y1 = sections
           info['x0'] = x0.to_i
           info['y0'] = y0.to_i
           info['x1'] = x1.to_i
           info['y1'] = y1.to_i
-        elsif /^x_wconf/.match(part)
+        elsif /^x_wconf/ =~ part
           c = sections.first
           info['c'] = c.to_i
         end

--- a/lib/iu_metadata/variations_record.rb
+++ b/lib/iu_metadata/variations_record.rb
@@ -146,7 +146,7 @@ module IuMetadata
 
       def filename(file_node)
         normalized = file_node.xpath('FileName').first&.content.to_s.downcase.sub(/\.\w{3,4}/, '')
-        if normalized.match(/^\d+$/)
+        if normalized =~ /^\d+$/
           root = source_metadata_identifier.downcase
           volume = 1
           page = normalized


### PR DESCRIPTION
One rule was disabled locally, because the block is actually used by name in a later line, passing it to another method.

Passes spec suite and RuboCop is happy.