### PR TITLE
HPT-1268 Fixes case sensitivity in SearchController affecting OCR searching

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -12,7 +12,8 @@ class SearchController < ApplicationController
                                       fq: "ordered_by_ssim:#{params[:id]}")
     @docs = @response.map do |doc|
       doc_text = doc['full_text_tesim'][0]
-      doc[:hit_number] = doc_text.scan(/\w+/).count(search_term)
+      doc[:hit_number] =
+        doc_text.scan(/\w+/).count { |t| t.casecmp(search_term).zero? }
       doc[:word] = search_term
       doc
     end

--- a/app/views/search/_resource.json.jbuilder
+++ b/app/views/search/_resource.json.jbuilder
@@ -8,10 +8,11 @@ json.resource do
 end
 
 page_word_list = @pages_json[doc[:id]]
-xywh = if !@pages_json[doc[:id]] || page_word_list[doc[:word]].nil?
+real_key = page_word_list.keys.find { |k| doc[:word].downcase == k.downcase }
+xywh = if !@pages_json[doc[:id]] || page_word_list[real_key].nil?
   "0,0,0,0"
 else
-  word_bounds = page_word_list[doc[:word]].shift
+  word_bounds = page_word_list[real_key].shift
   # FIXME: This is the wrong place to set all of these to integers
   if word_bounds
     x = word_bounds["x0"].to_i


### PR DESCRIPTION
Fixes SearchController and parts of the JSON response builders that uses a Solr response to derive OCR search hits and retrieve word boundary data.