### PR TITLE
HPT-1307 rubocop fix for rspec multipleExpectations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -169,7 +169,8 @@ RSpec/MessageSpies:
   Enabled: false
 
 RSpec/MultipleExpectations:
-  Enabled: false
+  Enabled: true
+  Max: 8
 
 RSpec/NestedGroups:
   Enabled: true

--- a/spec/ability/iu_roles_spec.rb
+++ b/spec/ability/iu_roles_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 require "cancan/matchers"
 
-# rubocop:disable RSpec/ExampleLength
 describe Ability do
   subject { ability }
 
@@ -141,6 +140,8 @@ describe Ability do
       is_expected.to be_able_to(:read, flagged_scanned_resource)
       is_expected.to be_able_to(:pdf, open_scanned_resource)
       is_expected.to be_able_to(:color_pdf, open_scanned_resource)
+    }
+    it {
       is_expected.to be_able_to(:edit, open_scanned_resource)
       is_expected.to be_able_to(:edit, open_scanned_resource_presenter.id)
       is_expected.to be_able_to(:edit, private_scanned_resource)
@@ -149,6 +150,8 @@ describe Ability do
       is_expected.to be_able_to(:file_manager, open_scanned_resource)
       is_expected.to be_able_to(:file_manager, open_multi_volume_work)
       is_expected.to be_able_to(:update, open_scanned_resource)
+    }
+    it {
       is_expected.to be_able_to(:update, private_scanned_resource)
       is_expected.to be_able_to(:update, takedown_scanned_resource)
       is_expected.to be_able_to(:update, flagged_scanned_resource)
@@ -156,6 +159,8 @@ describe Ability do
       is_expected.to be_able_to(:destroy, private_scanned_resource)
       is_expected.to be_able_to(:destroy, takedown_scanned_resource)
       is_expected.to be_able_to(:destroy, flagged_scanned_resource)
+    }
+    it {
       is_expected.to be_able_to(:manifest, open_scanned_resource)
       is_expected.to be_able_to(:manifest, pending_scanned_resource)
     }
@@ -174,6 +179,8 @@ describe Ability do
       is_expected.to be_able_to(:read, pending_scanned_resource)
       is_expected.to be_able_to(:read, metadata_review_scanned_resource)
       is_expected.to be_able_to(:read, final_review_scanned_resource)
+    }
+    it {
       is_expected.to be_able_to(:read, complete_scanned_resource)
       is_expected.to be_able_to(:read, takedown_scanned_resource)
       is_expected.to be_able_to(:read, flagged_scanned_resource)
@@ -182,6 +189,8 @@ describe Ability do
       is_expected.to be_able_to(:file_manager, open_multi_volume_work)
       is_expected.to be_able_to(:save_structure, open_scanned_resource)
       is_expected.to be_able_to(:update, open_scanned_resource)
+    }
+    it {
       is_expected.to be_able_to(:create, ScannedResource.new)
       is_expected.to be_able_to(:create, FileSet.new)
       is_expected.to be_able_to(:destroy, image_editor_file)
@@ -191,6 +200,8 @@ describe Ability do
       is_expected.not_to be_able_to(:destroy, role)
       is_expected.not_to be_able_to(:complete, pending_scanned_resource)
       is_expected.not_to be_able_to(:destroy, complete_scanned_resource)
+    }
+    it {
       is_expected.not_to be_able_to(:destroy, admin_file)
       is_expected.not_to be_able_to(:pdf, open_scanned_resource)
       is_expected.not_to be_able_to(:color_pdf, open_scanned_resource)
@@ -210,6 +221,8 @@ describe Ability do
       is_expected.to be_able_to(:read, final_review_scanned_resource)
       is_expected.to be_able_to(:read, complete_scanned_resource)
       is_expected.to be_able_to(:read, takedown_scanned_resource)
+    }
+    it {
       is_expected.to be_able_to(:read, flagged_scanned_resource)
       is_expected.to be_able_to(:manifest, open_scanned_resource)
       is_expected.to be_able_to(:flag, open_scanned_resource)
@@ -218,7 +231,8 @@ describe Ability do
       is_expected.to be_able_to(:file_manager, open_multi_volume_work)
       is_expected.to be_able_to(:save_structure, open_scanned_resource)
       is_expected.to be_able_to(:update, open_scanned_resource)
-
+    }
+    it {
       is_expected.not_to be_able_to(:download, image_editor_file)
       is_expected.not_to be_able_to(:create, ScannedResource.new)
       is_expected.not_to be_able_to(:create, FileSet.new)
@@ -227,6 +241,8 @@ describe Ability do
       is_expected.not_to be_able_to(:create, Role.new)
       is_expected.not_to be_able_to(:destroy, role)
       is_expected.not_to be_able_to(:complete, pending_scanned_resource)
+    }
+    it {
       is_expected.not_to be_able_to(:destroy, complete_scanned_resource)
       is_expected.not_to be_able_to(:destroy, admin_file)
       is_expected.not_to be_able_to(:pdf, open_scanned_resource)
@@ -247,15 +263,18 @@ describe Ability do
       is_expected.to be_able_to(:read, final_review_scanned_resource)
       is_expected.to be_able_to(:read, complete_scanned_resource)
       is_expected.to be_able_to(:read, takedown_scanned_resource)
+    }
+    it {
       is_expected.to be_able_to(:read, flagged_scanned_resource)
       is_expected.to be_able_to(:manifest, open_scanned_resource)
       is_expected.to be_able_to(:flag, open_scanned_resource)
       is_expected.to be_able_to(:flag, private_scanned_resource)
       is_expected.to be_able_to(:download, image_editor_file)
-
       is_expected.not_to be_able_to(:file_manager, open_scanned_resource)
       is_expected.not_to be_able_to(:file_manager, open_multi_volume_work)
       is_expected.not_to be_able_to(:save_structure, open_scanned_resource)
+    }
+    it {
       is_expected.not_to be_able_to(:update, open_scanned_resource)
       is_expected.not_to be_able_to(:create, ScannedResource.new)
       is_expected.not_to be_able_to(:create, FileSet.new)
@@ -264,6 +283,8 @@ describe Ability do
       is_expected.not_to be_able_to(:create, Role.new)
       is_expected.not_to be_able_to(:destroy, role)
       is_expected.not_to be_able_to(:complete, pending_scanned_resource)
+    }
+    it {
       is_expected.not_to be_able_to(:destroy, complete_scanned_resource)
       is_expected.not_to be_able_to(:destroy, admin_file)
       is_expected.not_to be_able_to(:pdf, open_scanned_resource)
@@ -282,10 +303,13 @@ describe Ability do
       is_expected.to be_able_to(:read, final_review_scanned_resource)
       is_expected.to be_able_to(:read, complete_scanned_resource)
       is_expected.to be_able_to(:read, takedown_scanned_resource)
+    }
+    it {
       is_expected.to be_able_to(:read, flagged_scanned_resource)
       is_expected.to be_able_to(:manifest, open_scanned_resource)
       is_expected.to be_able_to(:flag, open_scanned_resource)
-
+    }
+    it {
       is_expected.not_to be_able_to(:read, pending_scanned_resource)
       is_expected.not_to be_able_to(:download, image_editor_file)
       is_expected.not_to be_able_to(:file_manager, open_scanned_resource)
@@ -294,6 +318,8 @@ describe Ability do
       is_expected.not_to be_able_to(:update, open_scanned_resource)
       is_expected.not_to be_able_to(:create, ScannedResource.new)
       is_expected.not_to be_able_to(:create, FileSet.new)
+    }
+    it {
       is_expected.not_to be_able_to(:destroy, image_editor_file)
       is_expected.not_to be_able_to(:destroy, pending_scanned_resource)
       is_expected.not_to be_able_to(:destroy, complete_scanned_resource)
@@ -318,10 +344,13 @@ describe Ability do
       is_expected.to be_able_to(:manifest, campus_only_scanned_resource)
       is_expected.to be_able_to(:manifest, complete_scanned_resource)
       is_expected.to be_able_to(:manifest, flagged_scanned_resource)
+    }
+    it {
       is_expected.to be_able_to(:flag, open_scanned_resource)
       is_expected.to be_able_to(:flag, campus_only_scanned_resource)
       is_expected.to be_able_to(:flag, complete_scanned_resource)
-
+    }
+    it {
       is_expected.not_to be_able_to(:read, private_scanned_resource)
       is_expected.not_to be_able_to(:read, pending_scanned_resource)
       is_expected.not_to be_able_to(:read, metadata_review_scanned_resource)
@@ -330,6 +359,8 @@ describe Ability do
       is_expected.not_to be_able_to(:download, image_editor_file)
       is_expected.not_to be_able_to(:file_manager, open_scanned_resource)
       is_expected.not_to be_able_to(:file_manager, open_multi_volume_work)
+    }
+    it {
       is_expected.not_to be_able_to(:save_structure, open_scanned_resource)
       is_expected.not_to be_able_to(:update, open_scanned_resource)
       is_expected.not_to be_able_to(:create, ScannedResource.new)
@@ -338,6 +369,8 @@ describe Ability do
       is_expected.not_to be_able_to(:destroy, pending_scanned_resource)
       is_expected.not_to be_able_to(:destroy, complete_scanned_resource)
       is_expected.not_to be_able_to(:create, Role.new)
+    }
+    it {
       is_expected.not_to be_able_to(:destroy, role)
       is_expected.not_to be_able_to(:complete, pending_scanned_resource)
       is_expected.not_to be_able_to(:destroy, admin_file)
@@ -372,7 +405,8 @@ describe Ability do
       is_expected.to be_able_to(:manifest, complete_scanned_resource)
       is_expected.to be_able_to(:read, flagged_scanned_resource)
       is_expected.to be_able_to(:manifest, flagged_scanned_resource)
-
+    }
+    it {
       is_expected.not_to be_able_to(:color_pdf, color_enabled_resource)
       is_expected.not_to be_able_to(:pdf, open_scanned_resource)
       is_expected.not_to be_able_to(:pdf, no_pdf_scanned_resource)
@@ -381,6 +415,8 @@ describe Ability do
       is_expected.not_to be_able_to(:read, private_scanned_resource)
       is_expected.not_to be_able_to(:read, pending_scanned_resource)
       is_expected.not_to be_able_to(:read, metadata_review_scanned_resource)
+    }
+    it {
       is_expected.not_to be_able_to(:read, final_review_scanned_resource)
       is_expected.not_to be_able_to(:read, takedown_scanned_resource)
       is_expected.not_to be_able_to(:download, image_editor_file)
@@ -389,6 +425,8 @@ describe Ability do
       is_expected.not_to be_able_to(:save_structure, open_scanned_resource)
       is_expected.not_to be_able_to(:update, open_scanned_resource)
       is_expected.not_to be_able_to(:create, ScannedResource.new)
+    }
+    it {
       is_expected.not_to be_able_to(:create, FileSet.new)
       is_expected.not_to be_able_to(:destroy, image_editor_file)
       is_expected.not_to be_able_to(:destroy, pending_scanned_resource)
@@ -423,7 +461,8 @@ describe Ability do
       is_expected.to be_able_to(:manifest, complete_scanned_resource)
       is_expected.to be_able_to(:read, flagged_scanned_resource)
       is_expected.to be_able_to(:manifest, flagged_scanned_resource)
-
+    }
+    it {
       is_expected.not_to be_able_to(:color_pdf, color_enabled_resource)
       is_expected.not_to be_able_to(:pdf, open_scanned_resource)
       is_expected.not_to be_able_to(:pdf, no_pdf_scanned_resource)
@@ -432,6 +471,8 @@ describe Ability do
       is_expected.not_to be_able_to(:read, private_scanned_resource)
       is_expected.not_to be_able_to(:read, pending_scanned_resource)
       is_expected.not_to be_able_to(:read, metadata_review_scanned_resource)
+    }
+    it {
       is_expected.not_to be_able_to(:read, final_review_scanned_resource)
       is_expected.not_to be_able_to(:read, takedown_scanned_resource)
       is_expected.not_to be_able_to(:download, image_editor_file)
@@ -440,6 +481,8 @@ describe Ability do
       is_expected.not_to be_able_to(:save_structure, open_scanned_resource)
       is_expected.not_to be_able_to(:update, open_scanned_resource)
       is_expected.not_to be_able_to(:create, ScannedResource.new)
+    }
+    it {
       is_expected.not_to be_able_to(:create, FileSet.new)
       is_expected.not_to be_able_to(:destroy, image_editor_file)
       is_expected.not_to be_able_to(:destroy, pending_scanned_resource)
@@ -451,4 +494,3 @@ describe Ability do
     }
   end
 end
-# rubocop:enable RSpec/ExampleLength

--- a/spec/ability/roles_spec.rb
+++ b/spec/ability/roles_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 require "cancan/matchers"
 
-# rubocop:disable RSpec/ExampleLength
 describe Ability do
   subject { ability }
 
@@ -123,6 +122,8 @@ describe Ability do
       is_expected.to be_able_to(:read, flagged_scanned_resource)
       is_expected.to be_able_to(:pdf, open_scanned_resource)
       is_expected.to be_able_to(:color_pdf, open_scanned_resource)
+    }
+    it {
       is_expected.to be_able_to(:edit, open_scanned_resource)
       is_expected.to be_able_to(:edit, open_scanned_resource_presenter.id)
       is_expected.to be_able_to(:edit, private_scanned_resource)
@@ -131,6 +132,8 @@ describe Ability do
       is_expected.to be_able_to(:file_manager, open_scanned_resource)
       is_expected.to be_able_to(:file_manager, open_multi_volume_work)
       is_expected.to be_able_to(:update, open_scanned_resource)
+    }
+    it {
       is_expected.to be_able_to(:update, private_scanned_resource)
       is_expected.to be_able_to(:update, takedown_scanned_resource)
       is_expected.to be_able_to(:update, flagged_scanned_resource)
@@ -139,6 +142,8 @@ describe Ability do
       is_expected.to be_able_to(:destroy, takedown_scanned_resource)
       is_expected.to be_able_to(:destroy, flagged_scanned_resource)
       is_expected.to be_able_to(:manifest, open_scanned_resource)
+    }
+    it {
       is_expected.to be_able_to(:manifest, pending_scanned_resource)
     }
   end
@@ -156,6 +161,8 @@ describe Ability do
       is_expected.to be_able_to(:read, campus_only_scanned_resource)
       is_expected.to be_able_to(:read, private_scanned_resource)
       is_expected.to be_able_to(:read, pending_scanned_resource)
+    }
+    it {
       is_expected.to be_able_to(:read, metadata_review_scanned_resource)
       is_expected.to be_able_to(:read, final_review_scanned_resource)
       is_expected.to be_able_to(:read, complete_scanned_resource)
@@ -164,15 +171,18 @@ describe Ability do
       is_expected.to be_able_to(:download, image_editor_file)
       is_expected.to be_able_to(:file_manager, open_scanned_resource)
       is_expected.to be_able_to(:file_manager, open_multi_volume_work)
+    }
+    it {
       is_expected.to be_able_to(:save_structure, open_scanned_resource)
       is_expected.to be_able_to(:update, open_scanned_resource)
       is_expected.to be_able_to(:create, ScannedResource.new)
       is_expected.to be_able_to(:create, FileSet.new)
       is_expected.to be_able_to(:destroy, image_editor_file)
       is_expected.to be_able_to(:destroy, pending_scanned_resource)
-
       is_expected.not_to be_able_to(:create, Role.new)
       is_expected.not_to be_able_to(:destroy, role)
+    }
+    it {
       is_expected.not_to be_able_to(:complete, pending_scanned_resource)
       is_expected.not_to be_able_to(:destroy, complete_scanned_resource)
       is_expected.not_to be_able_to(:destroy, admin_file)
@@ -192,6 +202,8 @@ describe Ability do
       is_expected.to be_able_to(:read, final_review_scanned_resource)
       is_expected.to be_able_to(:read, complete_scanned_resource)
       is_expected.to be_able_to(:read, takedown_scanned_resource)
+    }
+    it {
       is_expected.to be_able_to(:read, flagged_scanned_resource)
       is_expected.to be_able_to(:manifest, open_scanned_resource)
       is_expected.not_to be_able_to(:pdf, open_scanned_resource)
@@ -200,15 +212,18 @@ describe Ability do
       is_expected.to be_able_to(:flag, private_scanned_resource)
       is_expected.to be_able_to(:file_manager, open_scanned_resource)
       is_expected.to be_able_to(:file_manager, open_multi_volume_work)
+    }
+    it {
       is_expected.to be_able_to(:save_structure, open_scanned_resource)
       is_expected.to be_able_to(:update, open_scanned_resource)
-
       is_expected.not_to be_able_to(:download, image_editor_file)
       is_expected.not_to be_able_to(:create, ScannedResource.new)
       is_expected.not_to be_able_to(:create, FileSet.new)
       is_expected.not_to be_able_to(:destroy, image_editor_file)
       is_expected.not_to be_able_to(:destroy, pending_scanned_resource)
       is_expected.not_to be_able_to(:create, Role.new)
+    }
+    it {
       is_expected.not_to be_able_to(:destroy, role)
       is_expected.not_to be_able_to(:complete, pending_scanned_resource)
       is_expected.not_to be_able_to(:destroy, complete_scanned_resource)
@@ -229,13 +244,16 @@ describe Ability do
       is_expected.to be_able_to(:read, final_review_scanned_resource)
       is_expected.to be_able_to(:read, complete_scanned_resource)
       is_expected.to be_able_to(:read, takedown_scanned_resource)
+    }
+    it {
       is_expected.to be_able_to(:read, flagged_scanned_resource)
       is_expected.to be_able_to(:manifest, open_scanned_resource)
       is_expected.not_to be_able_to(:pdf, open_scanned_resource)
       is_expected.to be_able_to(:flag, open_scanned_resource)
       is_expected.to be_able_to(:flag, private_scanned_resource)
       is_expected.to be_able_to(:download, image_editor_file)
-
+    }
+    it {
       is_expected.not_to be_able_to(:file_manager, open_scanned_resource)
       is_expected.not_to be_able_to(:file_manager, open_multi_volume_work)
       is_expected.not_to be_able_to(:save_structure, open_scanned_resource)
@@ -244,6 +262,8 @@ describe Ability do
       is_expected.not_to be_able_to(:create, FileSet.new)
       is_expected.not_to be_able_to(:destroy, image_editor_file)
       is_expected.not_to be_able_to(:destroy, pending_scanned_resource)
+    }
+    it {
       is_expected.not_to be_able_to(:create, Role.new)
       is_expected.not_to be_able_to(:destroy, role)
       is_expected.not_to be_able_to(:complete, pending_scanned_resource)
@@ -265,15 +285,18 @@ describe Ability do
       is_expected.to be_able_to(:read, complete_scanned_resource)
       is_expected.to be_able_to(:read, takedown_scanned_resource)
       is_expected.to be_able_to(:read, flagged_scanned_resource)
+    }
+    it {
       is_expected.to be_able_to(:manifest, open_scanned_resource)
       is_expected.not_to be_able_to(:pdf, open_scanned_resource)
       is_expected.to be_able_to(:flag, open_scanned_resource)
-
       is_expected.not_to be_able_to(:read, pending_scanned_resource)
       is_expected.not_to be_able_to(:download, image_editor_file)
       is_expected.not_to be_able_to(:file_manager, open_scanned_resource)
       is_expected.not_to be_able_to(:file_manager, open_multi_volume_work)
       is_expected.not_to be_able_to(:save_structure, open_scanned_resource)
+    }
+    it {
       is_expected.not_to be_able_to(:update, open_scanned_resource)
       is_expected.not_to be_able_to(:create, ScannedResource.new)
       is_expected.not_to be_able_to(:create, FileSet.new)
@@ -282,6 +305,8 @@ describe Ability do
       is_expected.not_to be_able_to(:destroy, complete_scanned_resource)
       is_expected.not_to be_able_to(:create, Role.new)
       is_expected.not_to be_able_to(:destroy, role)
+    }
+    it {
       is_expected.not_to be_able_to(:complete, pending_scanned_resource)
       is_expected.not_to be_able_to(:destroy, admin_file)
     }
@@ -300,6 +325,8 @@ describe Ability do
       is_expected.to be_able_to(:manifest, campus_only_scanned_resource)
       is_expected.to be_able_to(:manifest, complete_scanned_resource)
       is_expected.to be_able_to(:manifest, flagged_scanned_resource)
+    }
+    it {
       is_expected.not_to be_able_to(:pdf, open_scanned_resource)
       is_expected.not_to be_able_to(:pdf, campus_only_scanned_resource)
       is_expected.not_to be_able_to(:pdf, complete_scanned_resource)
@@ -307,7 +334,8 @@ describe Ability do
       is_expected.to be_able_to(:flag, open_scanned_resource)
       is_expected.to be_able_to(:flag, campus_only_scanned_resource)
       is_expected.to be_able_to(:flag, complete_scanned_resource)
-
+    }
+    it {
       is_expected.not_to be_able_to(:read, private_scanned_resource)
       is_expected.not_to be_able_to(:read, pending_scanned_resource)
       is_expected.not_to be_able_to(:read, metadata_review_scanned_resource)
@@ -316,6 +344,8 @@ describe Ability do
       is_expected.not_to be_able_to(:download, image_editor_file)
       is_expected.not_to be_able_to(:file_manager, open_scanned_resource)
       is_expected.not_to be_able_to(:file_manager, open_multi_volume_work)
+    }
+    it {
       is_expected.not_to be_able_to(:save_structure, open_scanned_resource)
       is_expected.not_to be_able_to(:update, open_scanned_resource)
       is_expected.not_to be_able_to(:create, ScannedResource.new)
@@ -324,6 +354,8 @@ describe Ability do
       is_expected.not_to be_able_to(:destroy, pending_scanned_resource)
       is_expected.not_to be_able_to(:destroy, complete_scanned_resource)
       is_expected.not_to be_able_to(:create, Role.new)
+    }
+    it {
       is_expected.not_to be_able_to(:destroy, role)
       is_expected.not_to be_able_to(:complete, pending_scanned_resource)
       is_expected.not_to be_able_to(:destroy, admin_file)
@@ -355,7 +387,8 @@ describe Ability do
       is_expected.to be_able_to(:read, flagged_scanned_resource)
       is_expected.to be_able_to(:manifest, flagged_scanned_resource)
       is_expected.not_to be_able_to(:color_pdf, color_enabled_resource)
-
+    }
+    it {
       is_expected.not_to be_able_to(:pdf, no_pdf_scanned_resource)
       is_expected.not_to be_able_to(:flag, open_scanned_resource)
       is_expected.not_to be_able_to(:read, campus_only_scanned_resource)
@@ -364,6 +397,8 @@ describe Ability do
       is_expected.not_to be_able_to(:read, metadata_review_scanned_resource)
       is_expected.not_to be_able_to(:read, final_review_scanned_resource)
       is_expected.not_to be_able_to(:read, takedown_scanned_resource)
+    }
+    it {
       is_expected.not_to be_able_to(:download, image_editor_file)
       is_expected.not_to be_able_to(:file_manager, open_scanned_resource)
       is_expected.not_to be_able_to(:file_manager, open_multi_volume_work)
@@ -372,6 +407,8 @@ describe Ability do
       is_expected.not_to be_able_to(:create, ScannedResource.new)
       is_expected.not_to be_able_to(:create, FileSet.new)
       is_expected.not_to be_able_to(:destroy, image_editor_file)
+    }
+    it {
       is_expected.not_to be_able_to(:destroy, pending_scanned_resource)
       is_expected.not_to be_able_to(:destroy, complete_scanned_resource)
       is_expected.not_to be_able_to(:create, Role.new)
@@ -381,4 +418,3 @@ describe Ability do
     }
   end
 end
-# rubocop:enable RSpec/ExampleLength

--- a/spec/jobs/ingest_yaml_job_spec.rb
+++ b/spec/jobs/ingest_yaml_job_spec.rb
@@ -108,6 +108,7 @@ RSpec.describe IngestYAMLJob do
 
     shared_examples "ingest cases" do
       # rubocop:disable RSpec/ExampleLength
+      # rubocop:disable RSpec/MultipleExpectations
       it "ingests a single-volume yaml file" do
         expect(actor1).to receive(:attach_related_object).with(resource1)
         expect(actor1).to receive(:attach_content).with(instance_of(File))
@@ -132,6 +133,7 @@ RSpec.describe IngestYAMLJob do
           Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
         )
       end
+      # rubocop:enable RSpec/MultipleExpectations
       # rubocop:enable RSpec/ExampleLength
       it "ingests a right-to-left yaml file" do
         allow(actor1).to receive(:attach_related_object)
@@ -232,7 +234,7 @@ RSpec.describe IngestYAMLJob do
       allow(IngestFileJob).to receive(:perform_later).and_return(true)
       allow(CharacterizeJob).to receive(:perform_later).and_return(true)
     end
-
+    # rubocop:disable RSpec/MultipleExpectations
     it "ingests a yaml file" do
       described_class.perform_now(mets_file, user,
                                   file_association_method: 'individual')
@@ -253,5 +255,6 @@ RSpec.describe IngestYAMLJob do
         "<mets:mets"
       )
     end
+    # rubocop:enable RSpec/MultipleExpectations
   end
 end

--- a/spec/models/state_workflow_spec.rb
+++ b/spec/models/state_workflow_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe StateWorkflow do
   let(:workflow) { described_class.new :pending }
 
+  # rubocop:disable RSpec/MultipleExpectations
   describe 'ingest workflow' do
     # rubocop:disable RSpec/ExampleLength
     it 'proceeds through ingest workflow' do
@@ -101,6 +102,7 @@ describe StateWorkflow do
       expect(workflow.suppressed?).to be false
     end
   end
+  # rubocop:enable RSpec/MultipleExpectations
 
   describe 'persistence' do
     states = %i[pending metadata_review final_review complete flagged takedown]


### PR DESCRIPTION
Some notes about the fix
1. Carefully picked Max: 8. This number lowered the rubocop complains from 130+ to 10+
2. Grouped the statements to 8 in iu_role_spec.rb and  roles_spec.rb. This will also fix rubocop RSpec/ExampleLength (removed the disable ExampleLength)
3. Cannot group the statements in ingest_yaml_job_spec.rb and state_wrokflow_spec.rb to 8 (Group will let rubocop pass, but got a lot of test errors), the only way I can think about is disable multipleExpectations check. 