### PR TITLE
HPT-1304 Rubocop Rspec/ExpectInHook

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -162,9 +162,6 @@ RSpec/ExampleLength:
   Enabled: true
   Max: 20
 
-RSpec/ExpectInHook:
-  Enabled: false
-
 RSpec/MessageSpies:
   Enabled: false
 

--- a/spec/ability/iu_roles_spec.rb
+++ b/spec/ability/iu_roles_spec.rb
@@ -76,6 +76,7 @@ describe Ability do
       ['Test-Group'] # Enables LDAP lookup system
     allow(Plum).to receive(:config).and_return(config)
     # Do not make any real LDAP requests
+    # rubocop:disable RSpec/ExpectInHook
     expect_any_instance_of(Net::LDAP).not_to receive(:search)
     [
       admin_user,
@@ -88,6 +89,7 @@ describe Ability do
       allow(obj).to receive(:member_of_ldap_group?) \
         .with(config[:authorized_ldap_groups]).and_return(true)
     end
+    # rubocop:enable RSpec/ExpectInHook
     allow(campus_user).to receive(:member_of_ldap_group?) \
       .with(config[:authorized_ldap_groups]).and_return(false)
     allow(open_scanned_resource).to receive(:id).and_return("open")

--- a/spec/services/browse_everything_ingester_spec.rb
+++ b/spec/services/browse_everything_ingester_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe BrowseEverythingIngester do
   describe "#save" do
     let(:download_path) { Rails.root.join("tmp", "spec", "downloaded.tif") }
 
+    # rubocop:disable RSpec/ExpectInHook
     before do
       FileUtils.mkdir_p(download_path.dirname)
       FileUtils.cp(file.path, download_path)
@@ -33,6 +34,7 @@ RSpec.describe BrowseEverythingIngester do
       allow_any_instance_of(BrowseEverything::Retriever) \
         .to receive(:download).and_return(download_path)
     end
+    # rubocop:enable RSpec/ExpectInHook
     it "cleans up the downloaded file" do
       ingester.save
 

--- a/spec/services/extra_lockable_spec.rb
+++ b/spec/services/extra_lockable_spec.rb
@@ -5,12 +5,14 @@ RSpec.describe ExtraLockable do
   let(:work_id) { work.source_metadata_identifier }
   let(:lock_info) { nil }
 
+  # rubocop:disable RSpec/ExpectInHook
   around { |example|
     # Ensure there are no existing locks before and after.
     expect(work.lock?(work_id)).to eq false
     example.run
     work.unlock(lock_info) if work.lock?(work_id)
   }
+  # rubocop:enable RSpec/ExpectInHook
 
   describe 'lock_id_attribute' do
     it 'is id by default' do

--- a/spec/validators/exhibit_id_validator_spec.rb
+++ b/spec/validators/exhibit_id_validator_spec.rb
@@ -15,11 +15,13 @@ RSpec.describe ExhibitIdValidator do
       }.stringify_keys
     }
 
+    # rubocop:disable RSpec/ExpectInHook
     before do
       expect(ActiveFedora::SolrService).to receive(:get) \
         .and_return(solr_response)
       allow(errors).to receive(:add)
     end
+    # rubocop:enable RSpec/ExpectInHook
 
     context "when the exhibit id unique" do
       it "does not add errors" do


### PR DESCRIPTION
Tried many ways to move expect statements out of the before, after, around loops. Rubocop seems ok but tests failed always.  The workaround is to disable the ExpectInHoop check in these four cases. 