### PR TITLE
[HPT-1329] Fixes empty blacklight search routing error.

### DIFF
--- a/config/initializers/blacklight_helpers.rb
+++ b/config/initializers/blacklight_helpers.rb
@@ -24,6 +24,6 @@ Blacklight::UrlHelperBehavior.module_eval do
   # @param [Object] SOLR document
   # @return [String] url string
   def add_highlight_url(doc)
-    params.key?(:q) && !params['q'].empty? ? url_for_document(doc).to_s + "/highlight/" + CGI.escape(params['q']) : url_for_document(doc)
+    params['q'].present? ? url_for_document(doc).to_s + "/highlight/" + CGI.escape(params['q']) : url_for_document(doc)
   end
 end

--- a/config/initializers/blacklight_helpers.rb
+++ b/config/initializers/blacklight_helpers.rb
@@ -24,6 +24,6 @@ Blacklight::UrlHelperBehavior.module_eval do
   # @param [Object] SOLR document
   # @return [String] url string
   def add_highlight_url(doc)
-    params.key?(:q) ? url_for_document(doc).to_s + "/highlight/" + CGI.escape(params['q']) : url_for_document(doc)
+    params.key?(:q) && !params['q'].empty? ? url_for_document(doc).to_s + "/highlight/" + CGI.escape(params['q']) : url_for_document(doc)
   end
 end


### PR DESCRIPTION
A team Randy bug fix. 

/highlight will not be included in Blacklight search result links when search string is empty (ie magnify glass clicked with no search string). 