### PR TITLE
[HPT-1306] RSpec/MesssageSpies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -160,7 +160,11 @@ RSpec/ExampleLength:
   Max: 20
 
 RSpec/MessageSpies:
-  Enabled: false
+  Enabled: true
+  EnforcedStyle: have_received
+  SupportedStyles:
+  - have_received
+  - receive
 
 RSpec/MultipleExpectations:
   Enabled: true

--- a/spec/ability/iu_roles_spec.rb
+++ b/spec/ability/iu_roles_spec.rb
@@ -79,6 +79,7 @@ describe Ability do
     # Do not make any real LDAP requests
     allow(Net::LDAP).to receive(:new).and_return(ldap)
     # rubocop:disable RSpec/ExpectInHook
+    # rubocop:disable RSpec/MessageSpies
     expect(ldap).not_to receive(:search)
     [
       admin_user,
@@ -92,6 +93,7 @@ describe Ability do
         .with(config[:authorized_ldap_groups]).and_return(true)
     end
     # rubocop:enable RSpec/ExpectInHook
+    # rubocop:enable RSpec/MessageSpies
     allow(campus_user).to receive(:member_of_ldap_group?) \
       .with(config[:authorized_ldap_groups]).and_return(false)
     allow(open_scanned_resource).to receive(:id).and_return("open")

--- a/spec/controllers/curation_concerns/scanned_resources_controller_spec.rb
+++ b/spec/controllers/curation_concerns/scanned_resources_controller_spec.rb
@@ -187,7 +187,9 @@ describe CurationConcerns::ScannedResourcesController do
         solr.add resource.to_solr
         solr.add resource2.to_solr
         solr.commit
+        # rubocop:disable RSpec/MessageSpies
         expect(ScannedResource).not_to receive(:find)
+        # rubocop:enable RSpec/MessageSpies
 
         get :manifest, id: "test2", format: :json
 

--- a/spec/jobs/ingest_file_job_spec.rb
+++ b/spec/jobs/ingest_file_job_spec.rb
@@ -8,8 +8,10 @@ describe IngestFileJob do
 
   context 'when :store_original_files is false' do
     it 'sets the mime_type to an external body redirect' do
+      # rubocop:disable RSpec/MessageSpies
       expect(CreateDerivativesJob).to receive(:perform_now) \
         .with(file_set, String, String)
+      # rubocop:enable RSpec/MessageSpies
       allow(Plum.config).to receive(:[]) \
         .with(:store_original_files) \
         .and_return(false)
@@ -32,8 +34,10 @@ describe IngestFileJob do
 
   context 'when :store_original_files is true' do
     it 'sets the mime_type to an external body redirect' do
+      # rubocop:disable RSpec/MessageSpies
       expect(CharacterizeJob).to receive(:perform_later) \
         .with(file_set, String)
+      # rubocop:enable RSpec/MessageSpies
       allow(Plum.config).to receive(:[]) \
         .with(:store_original_files) \
         .and_return(true)

--- a/spec/jobs/ingest_yaml_job_spec.rb
+++ b/spec/jobs/ingest_yaml_job_spec.rb
@@ -118,6 +118,7 @@ RSpec.describe IngestYAMLJob do
       # rubocop:disable RSpec/ExampleLength
       # rubocop:disable RSpec/MultipleExpectations
       it "ingests a single-volume yaml file" do
+        # rubocop:disable RSpec/MessageSpies
         expect(actor1).to receive(:attach_related_object).with(resource1)
         expect(actor1).to receive(:attach_content).with(instance_of(File))
         if file_association_method.in? ['batch', 'none']
@@ -128,6 +129,7 @@ RSpec.describe IngestYAMLJob do
         expect(actor2).to receive(:create_content).with(file)
         expect(actor2).to receive(:assign_visibility).with(resource1)
         expect(ingest_counter).to receive(:increment)
+        # rubocop:enable RSpec/MessageSpies
         described_class.perform_now(yaml_file_single, user,
                                     file_association_method:
                                     file_association_method)
@@ -167,6 +169,7 @@ RSpec.describe IngestYAMLJob do
         allow(actor2).to receive(:create_metadata)
         allow(actor2).to receive(:create_content)
         allow(actor2).to receive(:assign_visibility)
+        # rubocop:disable RSpec/MessageSpies
         expect(resource1).to receive(:logical_order) \
           .at_least(:once) \
           .and_return(logical_order)
@@ -174,6 +177,7 @@ RSpec.describe IngestYAMLJob do
           .at_least(:once) \
           .and_return(logical_order)
         expect(logical_order).to receive(:order=).at_least(:once)
+        # rubocop:enable RSpec/MessageSpies
         allow(logical_order).to receive(:order).and_return(nil)
         allow(logical_order).to receive(:object).and_return(order_object)
         allow(order_object).to receive(:each_section).and_return([])

--- a/spec/jobs/preingest_job_spec.rb
+++ b/spec/jobs/preingest_job_spec.rb
@@ -8,7 +8,9 @@ RSpec.describe PreingestJob do
       yaml_content = File.open(yaml_file) { |f| Psych.load(f) }
       yaml_content[:sources][0][:file] =
         Rails.root.join(yaml_content[:sources][0][:file]).to_s
+      # rubocop:disable RSpec/MessageSpies
       expect(File).to receive(:write).with(yaml_file, yaml_content.to_yaml)
+      # rubocop:enable RSpec/MessageSpies
       described_class.perform_now(document_class, preingest_file, user)
     end
   end

--- a/spec/jobs/run_word_boundaries_job_spec.rb
+++ b/spec/jobs/run_word_boundaries_job_spec.rb
@@ -11,9 +11,11 @@ RSpec.describe RunWordBoundariesJob do
         allow(WordBoundariesRunner).to receive(:new).and_return(mock_runner)
       end
       it "logs a message" do
+        # rubocop:disable RSpec/MessageSpies
         expect(Rails.logger).to receive(:info).with("WordBoundariesJob: 123")
         expect(Rails.logger).to receive(:info) \
           .with("WordBoundaries already exists for 123")
+        # rubocop:enable RSpec/MessageSpies
         job.perform('123')
       end
     end
@@ -26,8 +28,10 @@ RSpec.describe RunWordBoundariesJob do
         allow(WordBoundariesRunner).to receive(:new).and_return(@mock_runner)
       end
       it "creates a WordBoundariesRunner" do
+        # rubocop:disable RSpec/MessageSpies
         expect(Rails.logger).to receive(:info).with("WordBoundariesJob: 123")
         expect(@mock_runner).to receive(:create)
+        # rubocop:enable RSpec/MessageSpies
         job.perform('123')
       end
     end
@@ -42,10 +46,12 @@ RSpec.describe RunWordBoundariesJob do
         allow(described_class).to receive(:set).and_return(mock_job)
       end
       it "logs a message and set up to run later" do
+        # rubocop:disable RSpec/MessageSpies
         expect(Rails.logger).to receive(:info).with("WordBoundariesJob: 123")
         expect(Rails.logger).to receive(:info) \
           .with("WordBoundariesJob: Preconditions not met 123")
         expect(described_class).to receive(:set)
+        # rubocop:enable RSpec/MessageSpies
         job.perform('123')
       end
     end

--- a/spec/jobs/save_structure_job_spec.rb
+++ b/spec/jobs/save_structure_job_spec.rb
@@ -40,8 +40,10 @@ RSpec.describe SaveStructureJob do
   end
 
   it 'locks and unlocks the work' do
+    # rubocop:disable RSpec/MessageSpies
     expect(work).to receive(:lock).ordered
     expect(work).to receive(:unlock).ordered
+    # rubocop:enable RSpec/MessageSpies
     described_class.perform_now(work, structure)
   end
 end

--- a/spec/models/scanned_resource_spec.rb
+++ b/spec/models/scanned_resource_spec.rb
@@ -92,7 +92,9 @@ describe ScannedResource do
       before { scanned_resource.source_metadata_identifier = nil }
       it 'does nothing' do
         original_attributes = scanned_resource.attributes
+        # rubocop:disable RSpec/MessageSpies
         expect(scanned_resource.send(:remote_metadata_factory)).not_to receive(:new)
+        # rubocop:enable RSpec/MessageSpies
         scanned_resource.apply_remote_metadata
         expect(scanned_resource.attributes).to eq(original_attributes)
       end
@@ -205,13 +207,17 @@ describe ScannedResource do
     it "does not complete record when state doesn't change" do
       allow(scanned_resource).to receive("state_changed?").and_return false
       scanned_resource.state = 'complete'
+      # rubocop:disable RSpec/MessageSpies
       expect(scanned_resource).not_to receive(:complete_record)
+      # rubocop:enable RSpec/MessageSpies
       expect { scanned_resource.check_state } \
         .not_to(change { ActionMailer::Base.deliveries.count })
     end
     it "does not complete record when state isn't 'complete'" do
       scanned_resource.state = 'final_review'
+      # rubocop:disable RSpec/MessageSpies
       expect(scanned_resource).not_to receive(:complete_record)
+      # rubocop:enable RSpec/MessageSpies
       expect { scanned_resource.check_state } \
         .not_to(change { ActionMailer::Base.deliveries.count })
     end
@@ -219,7 +225,9 @@ describe ScannedResource do
       allow(scanned_resource).to receive("state_changed?").and_return true
       scanned_resource.state = 'complete'
       scanned_resource.identifier = '1234'
+      # rubocop:disable RSpec/MessageSpies
       expect(scanned_resource).not_to receive("identifier=")
+      # rubocop:enable RSpec/MessageSpies
       expect { scanned_resource.check_state } \
         .to change { ActionMailer::Base.deliveries.count }.by(1)
       expect(scanned_resource.identifier).to eq('1234')
@@ -227,7 +235,9 @@ describe ScannedResource do
     it "does not complete the record when the state transition is invalid" do
       allow(scanned_resource).to receive("state_changed?").and_return true
       scanned_resource.state = 'pending'
+      # rubocop:disable RSpec/MessageSpies
       expect(scanned_resource).not_to receive(:complete_record)
+      # rubocop:enable RSpec/MessageSpies
       expect { scanned_resource.check_state } \
         .not_to(change { ActionMailer::Base.deliveries.count })
       expect(scanned_resource.identifier).to eq(nil)

--- a/spec/services/ingest_counter_spec.rb
+++ b/spec/services/ingest_counter_spec.rb
@@ -11,7 +11,9 @@ RSpec.describe IngestCounter do
 
     it 'pauses http when limit is reached and resets count' do
       allow(Net::HTTP::Persistent).to receive(:new).and_return(http)
+      # rubocop:disable RSpec/MessageSpies
       expect(http).to receive(:shutdown)
+      # rubocop:enable RSpec/MessageSpies
       expect(counter.increment).to eq(1)
       expect(counter.increment).to eq(0)
     end

--- a/spec/services/word_boundaries_runner_spec.rb
+++ b/spec/services/word_boundaries_runner_spec.rb
@@ -20,7 +20,9 @@ RSpec.describe WordBoundariesRunner do
     context "when HOCR file is available" do
       # FIXME: either add unavailable context OR don't
       it "writes an equivalent jason representation" do
+        # rubocop:disable RSpec/MessageSpies
         expect(File).to receive(:write).with(runner.json_filepath, json)
+        # rubocop:enable RSpec/MessageSpies
         runner.create
       end
     end
@@ -31,15 +33,19 @@ RSpec.describe WordBoundariesRunner do
 
   describe "#hocr_filepath" do
     it "delegates to PairtreeDerivativePath" do
+      # rubocop:disable RSpec/MessageSpies
       expect(PairtreeDerivativePath) \
         .to receive(:derivative_path_for_reference).with(file_set, "ocr")
+      # rubocop:enable RSpec/MessageSpies
       runner.hocr_filepath
     end
   end
   describe "#json_filepath" do
     it "delegates to PairtreeDerivativePath" do
+      # rubocop:disable RSpec/MessageSpies
       expect(PairtreeDerivativePath) \
         .to receive(:derivative_path_for_reference).with(file_set, "json")
+      # rubocop:enable RSpec/MessageSpies
       runner.json_filepath
     end
   end

--- a/spec/validators/exhibit_id_validator_spec.rb
+++ b/spec/validators/exhibit_id_validator_spec.rb
@@ -17,8 +17,10 @@ RSpec.describe ExhibitIdValidator do
 
     # rubocop:disable RSpec/ExpectInHook
     before do
+      # rubocop:disable RSpec/MessageSpies
       expect(ActiveFedora::SolrService).to receive(:get) \
         .and_return(solr_response)
+      # rubocop:enable RSpec/MessageSpies
       allow(errors).to receive(:add)
     end
     # rubocop:enable RSpec/ExpectInHook


### PR DESCRIPTION
Selectively enable existing violations.
The problem with rewriting these, particularly in the case of jobs, is that meeting the requirement necessitates stubbing the method, when we may be dependent on its side-effects.