### PR TITLE
Adding checks for full_text_searchable in manifest builder and File Manager

### DIFF
--- a/app/services/manifest_builder/services_builder.rb
+++ b/app/services/manifest_builder/services_builder.rb
@@ -6,14 +6,13 @@ class ManifestBuilder
 
     def initialize(record)
       @record = record
-      # @searchable = record.full_text_searchable[0] unless record.full_text_searchable.nil?
     end
 
     def apply(manifest)
       return if
         record.class == AllCollectionsPresenter ||
         record.class == CollectionShowPresenter ||
-        searchable? == 'disabled'
+        !searchable?
       service_array = {
         "@context"  => "http://iiif.io/api/search/0/context.json",
         "@id"       => "#{root_url(protocol: protocol)}search/#{record.id}",
@@ -26,7 +25,9 @@ class ManifestBuilder
     private
 
       def searchable?
-        record.full_text_searchable[0] unless record.full_text_searchable.nil?
+        return false if record.full_text_searchable.nil?
+        return true if record.full_text_searchable[0] == 'enabled'
+        false
       end
 
       def protocol

--- a/app/views/curation_concerns/base/_file_manager_resource_form.html.erb
+++ b/app/views/curation_concerns/base/_file_manager_resource_form.html.erb
@@ -34,7 +34,7 @@
 
     <% searchable_opts = ['enabled', 'disabled'] %>
     <% searchable = @presenter.full_text_searchable[0] unless @presenter.full_text_searchable.nil? %>
-    <% selected_opt = searchable || searchable_opts.first %>
+    <% selected_opt = searchable || searchable_opts[1] %>
     <div id="search_opts">
       <label>Search within:</label>
       <% searchable_opts.each do |val| %>

--- a/spec/controllers/curation_concerns/scanned_resources_controller_spec.rb
+++ b/spec/controllers/curation_concerns/scanned_resources_controller_spec.rb
@@ -184,6 +184,7 @@ describe CurationConcerns::ScannedResourcesController do
         resource2 = FactoryGirl.build(:scanned_resource)
         allow(resource).to receive(:id).and_return("test")
         allow(resource2).to receive(:id).and_return("test2")
+        allow(resource2).to receive(:full_text_searchable).and_return("enabled")
         solr.add resource.to_solr
         solr.add resource2.to_solr
         solr.commit


### PR DESCRIPTION
Fixing the manifest builder which was excluding the search service definition only if `full_text searchable` was set to `disabled` so that it was being rendered when `nil`. It should explicitly enable it when full text search is enabled on a per work basis.  

Also fixes the search within option in the File Manger UI was defaulting to enabled if `full_text_searchable` was `nil`.