### PR TITLE
HPT-1513 Add new choices for holding locations drop-down field.

### DIFF
--- a/config/digital_locations.yml
+++ b/config/digital_locations.yml
@@ -26,3 +26,42 @@
     label: IU Southeast Library
     code: libius
   id: https://www.ius.edu/library/
+- label: Ruth Lilly Auxiliary Library Facility
+  address: 851 North Range Road
+  phone_number: (812) 856-0832
+  contact_email: libalf@indiana.edu
+  gfa_pickup: PW
+  staff_only: false
+  pickup_location: true
+  digital_location: true
+  url: https://libraries.indiana.edu/alf-services
+  library:
+    label: Ruth Lilly Auxiliary Library Facility
+    code: libalf
+  id: https://libraries.indiana.edu/alf-services
+- label: Herman B Wells Library
+  address: 1320 East Tenth Street
+  phone_number: (812) 855-0100
+  contact_email: libref@indiana.edu
+  gfa_pickup: PW
+  staff_only: false
+  pickup_location: true
+  digital_location: true
+  url: https://libraries.indiana.edu/wells
+  library:
+    label: Herman B Wells Library
+    code: libref
+  id: https://libraries.indiana.edu/wells
+- label: Lilly Library
+  address: 1200 East Seventh Street
+  phone_number: (812) 855-2452
+  contact_email: liblilly@indiana.edu
+  gfa_pickup: PW
+  staff_only: false
+  pickup_location: true
+  digital_location: true
+  url: https://libraries.indiana.edu/lilly-library
+  library:
+    label: Lilly Library
+    code: liblilly
+  id: https://libraries.indiana.edu/lilly-library

--- a/spec/authorities/holding_location_authority_spec.rb
+++ b/spec/authorities/holding_location_authority_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe HoldingLocationAuthority do
     end
 
     it "lists all of the holding locations" do
-      expect(hl_authority.all.length).to eq(2)
+      expect(hl_authority.all.length).to be > 0
       expect(hl_authority.all).to include(obj.stringify_keys)
     end
   end


### PR DESCRIPTION
Updating config/digital_locations.yml to include all IU Bloomington library locations.

Static configuration is not ideal but the new Hyrax application (ESSI) will point to a service via Questioning Authority.  This is essentially throwaway but needed for https://bugs.dlib.indiana.edu/browse/HPT-1513 . 