### PR TITLE
HPT-1554: Bugfix: highlighted search terms with a dot (.) raise an error

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,7 +65,7 @@ Rails.application.routes.draw do
         end
       end
     end
-    resources :multi_volume_works, only: [] do
+    resources :multi_volume_works, constraints: { search_term: /.*/ }, only: [] do
       member do
         get :manifest, defaults: { format: :json }
         get "/highlight/:search_term", action: :show
@@ -76,7 +76,7 @@ Rails.application.routes.draw do
         post :structure, action: :save_structure
       end
     end
-    resources :scanned_resources, only: [] do
+    resources :scanned_resources, constraints: { search_term: /.*/ }, only: [] do
       member do
         get "/pdf/:pdf_quality", action: :pdf, as: :pdf
         get "/highlight/:search_term", action: :show

--- a/spec/authorities/holding_location_authority_spec.rb
+++ b/spec/authorities/holding_location_authority_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe HoldingLocationAuthority do
     end
 
     it "lists all of the holding locations" do
-      expect(hl_authority.all.length).to be > 0
+      expect(hl_authority.all.length).to be_positive
       expect(hl_authority.all).to include(obj.stringify_keys)
     end
   end

--- a/spec/requests/multi_volume_work_request_spec.rb
+++ b/spec/requests/multi_volume_work_request_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe 'MultiVolumeWorksController', type: :request do
+  let(:user) { FactoryGirl.create(:image_editor) }
+  let(:multi_volume_work) { FactoryGirl.create(:multi_volume_work) }
+
+  describe 'User follows a link with a search highlight term' do
+    let(:resource_path) { curation_concerns_multi_volume_work_path(multi_volume_work.id) }
+    let(:search_term_path) { "#{resource_path}/highlight/#{search_term}" }
+
+    context 'with a period (.)' do
+      let(:search_term) { CGI.escape('Symphony No. 2') }
+
+      it 'does not raise ActionController::UnknownFormat' do
+        expect { get search_term_path }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/requests/scanned_resources_request_spec.rb
+++ b/spec/requests/scanned_resources_request_spec.rb
@@ -33,4 +33,17 @@ RSpec.describe 'ScannedResourcesController', type: :request do
     expect(response.body) \
       .to include('<h1 dir="ltr">The last resort : a novel</h1>')
   end
+
+  describe 'User follows a link with a search highlight term' do
+    let(:resource_path) { curation_concerns_scanned_resource_path(scanned_resource.id) }
+    let(:search_term_path) { "#{resource_path}/highlight/#{search_term}" }
+
+    context 'with a period (.)' do
+      let(:search_term) { CGI.escape('Symphony No. 2') }
+
+      it 'does not raise ActionController::UnknownFormat' do
+        expect { get search_term_path }.not_to raise_error
+      end
+    end
+  end
 end

--- a/spec/support/fedora_cleaner.rb
+++ b/spec/support/fedora_cleaner.rb
@@ -2,6 +2,6 @@ require 'active_fedora/cleaner'
 
 RSpec.configure do |config|
   config.before do
-    ActiveFedora::Cleaner.clean! if ActiveFedora::Base.count > 0
+    ActiveFedora::Cleaner.clean! if ActiveFedora::Base.count.positive?
   end
 end


### PR DESCRIPTION
The dot (.) doesn't actually need _escaping_, but normally gets interpreted by Rails as delimiter to specify request format (html, json, etc.), so we have to apply a routing constraint to prevent that.