### PR TITLE
Changing the default root route to catalog#index 

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,7 @@ Rails.application.routes.draw do
   mount Hydra::RoleManagement::Engine => '/'
 
   resources :welcome, only: 'index'
-  root to: 'welcome#index'
+  root to: 'catalog#index'
   # Add URL options
   default_url_options Rails.application.config.action_mailer.default_url_options
 

--- a/spec/features/root_spec.rb
+++ b/spec/features/root_spec.rb
@@ -8,24 +8,18 @@ RSpec.describe 'Home Page', type: :feature do
       sign_in user
     end
 
-    it 'Logged in users see welcome text and links to create content' do
+    it 'Logged in users see see search results with logout controls' do
       visit root_path
-      expect(page).to have_content('Pages Online')
-      expect(page).to have_selector('li.work-type/h3.title',
-                                    text: 'Scanned Resource')
-      expect(page).to have_selector('li.work-type/h3.title',
-                                    text: 'Collection')
+      expect(page).to have_content('Log Out')
+      page.assert_selector('div.search', count: 1)
     end
   end
 
   describe 'an anonymous user' do
-    it 'Anonymous users see only welcome text' do
+    it 'Anonymous users see search results but no logout controls' do
       visit root_path
-      expect(page).to have_content('Pages Online')
-      expect(page).not_to have_selector('li.work-type/h3.title',
-                                        text: 'Scanned Resource')
-      expect(page).not_to have_selector('li.work-type/h3.title',
-                                        text: 'Collection')
+      expect(page).not_to have_content('Log Out')
+      page.assert_selector('div.search', count: 1)
     end
   end
 end


### PR DESCRIPTION
Changing so that users always see available content via catalog search at root URL