### PR TITLE
Adding ability to redirect from PurlController based on requested format

### DIFF
--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -7,3 +7,4 @@ Mime::Type.register "application/ld+json", :jsonld
 Mime::Type.register "text/turtle", :ttl
 Mime::Type.register 'application/x-endnote-refer', :endnote
 Mime::Type.register "application/universalviewer", :uv
+Mime::Type.register "image/jp2", :jp2

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,6 +116,7 @@ Rails.application.routes.draw do
 
   # Purl redirects
   get '/purl/:id', to: 'purl#default', as: 'default_purl'
+  get '/purl/formats/:id', to: 'purl#formats', as: 'formats_purl'
 
   # iiif search API
   get '/search/:id', to: 'search#search', as: :search

--- a/spec/controllers/purl_controller_spec.rb
+++ b/spec/controllers/purl_controller_spec.rb
@@ -9,6 +9,12 @@ describe PurlController do
                        state: 'complete',
                        source_metadata_identifier: 'BHR9405')
   }
+  let(:file_set) {
+    FactoryGirl.create(:file_set,
+                       user: user,
+                       title: ['Page 5'],
+                       source_metadata_identifier: 'BHR9405-001-0005')
+  }
   let(:multi_volume_work) {
     FactoryGirl.create(:multi_volume_work,
                        user: user,
@@ -16,6 +22,30 @@ describe PurlController do
                        state: 'complete',
                        source_metadata_identifier: 'ABE9721')
   }
+
+  describe "formats" do
+    before do
+      sign_in user
+      file_set
+    end
+    context "when in jp2" do
+      before do
+        get :formats, id: id, format: format
+      end
+      let(:id) { file_set.source_metadata_identifier }
+      let(:format) { 'jp2' }
+      let(:model) { file_set.has_model[0] }
+
+      it "redirects to the correct location" do
+        if model && model == 'FileSet'
+          iiif_path = IIIFPath.new(file_set.id)
+          expect(response).to redirect_to "#{iiif_path}/full/!600,600/0/default.jpg"
+        else
+          expect(response).to redirect_to target_path
+        end
+      end
+    end
+  end
 
   describe "default" do
     let(:user) { FactoryGirl.create(:admin) }


### PR DESCRIPTION
This adds functionality to the PurlController to provide different redirects based on requests specifying a particular format extension.  This is handled via the 'variants' pattern inside of the `respond_to` block.  An example mime type and corresponding variant for 'jp2' is implemented, which facilitates a use case for the Newton project that will be using content loaded via Pages.