### PR TITLE
[ESSI-440] Modify WithProxyObject to filter out deleted image nodes

### DIFF
--- a/app/decorators/with_proxy_for_object.rb
+++ b/app/decorators/with_proxy_for_object.rb
@@ -31,6 +31,11 @@ class WithProxyForObject < SimpleDelegator
     end
   end
 
+  # Filters out any deleted nodes from UI presentation
+  def nodes
+    super.reject { |node| node.proxy_for_id.present? && node.proxy_for_object.nil? }
+  end
+
   private
 
     def all_nodes

--- a/spec/presenters/scanned_resource_show_presenter_spec.rb
+++ b/spec/presenters/scanned_resource_show_presenter_spec.rb
@@ -40,12 +40,25 @@ RSpec.describe ScannedResourceShowPresenter do
       allow(solr_document).to receive(:logical_order) \
         .and_return("nodes": [{ label: "Chapter 1", proxy: "test" }])
     end
-    it "returns a logical order object" do
-      expect(srs_presenter.logical_order_object.nodes.length).to eq 1
+    context "with nodes for live objects" do
+      before do
+        # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(WithProxyForObject).to \
+          receive(:proxy_for_object).and_return('something')
+        # rubocop:enable RSpec/AnyInstance
+      end
+      it "returns nodes" do
+        expect(srs_presenter.logical_order_object.nodes.length).to eq 1
+      end
     end
-    it "returns decorated nodes" do
-      expect(srs_presenter.logical_order_object.nodes.first) \
-        .to respond_to :proxy_for_object
+    context "with nodes for deleted objects" do
+      it "returns a logical order object with nodes rejected" do
+        expect(srs_presenter.logical_order_object.nodes).to be_empty
+      end
+      it "returns decorated logical order object" do
+        expect(srs_presenter.logical_order_object) \
+          .to respond_to :proxy_for_object
+      end
     end
   end
 


### PR DESCRIPTION
**Recreation of the bug:**
* Save a structure in the Structure Editor, containing at least one image FileSet.
  * This structure will be persisted in the `logical_order` relationship on the `ScannedResource`, and stored in solr as JSON in the `logical_order_tesim` field, and section headings as the `logical_order_headings_tesim` field.
* Delete an image `FileSet` contained in the persisted structure.
  * This will not impact the structure stored in solr, which is not automatically refreshed.
  * Reloading the objects `logical_order` and calling `#order`, an empty hash will now be present for the deleted `FileSet`.
* Reload the Structure Editor, and it will produce a ruby error trying to call `osd_modal_for(node.proxy_for_object.thumbnail_id)`, since `proxy_for_object` will return `nil` as the lookup for the `proxy_for_id` value will return nothing.
  * If solr _is_ updated, the Structure Editor will represent the empty node hash as an unlabeled subsection.

**What this does:**
The change presented here is to modify the `WithProxyForObject` decorator that the presenter applies to the `LogicalOrder` object, so that it rejects from the `nodes` results any node which presents an apparently valid `proxy_for_id` but returns a `nil` object. This allows a user to load the structure and then save it without the deleted `FileSet` entries included.

**What this does _not_ do:**
This does _not_ affect the `logical_order.order` output, which still contains an empty hash for a deleted `FileSet`.  That could potentially be caught and rejected, [here](https://github.com/IU-Libraries-Joint-Development/pumpkin/blob/master/app/values/logical_order_graph.rb#L18).

This also does _not_  add a callback to update the solr for a `ScannedResource` with an updated `logical_order.order` result.

**Some open questions, pertinent to both pumpkin and ESSI**
* Would we rather fix the problem at its source, but adding (1) an `after_delete` callback on a FileSet that refreshes the solrized `logical_order` on its parent, and (2) modifying `LogicalOrderGraph.to_h` to reject empty hash nodes, and (subsequently) empty arrays?
  * And if we're adding filtering effects into nodes results for `LogicalOrder` and/or `WithProxyForObject`, do we want to allow for optional parameters to toggle that filtering?
* Do we want or need the `SammelbandLogicalOrder` case in ESSI?
* Do we want to rearrange the infrastructure at all?  Specifically: the relationship of `LogicalOrderGraph` seems pretty clear, as its only function is to produce as hash representation of the logical order.  But `LogicalOrder` is a bit multipurpose in that it's the presentation layer for the UI, _and_ contains a `to_graph` method that's only used by `LogicalOrderBase` in order assignment.  It all works fine, but I wonder if segregating the UI-specific stuff from the internal mechanisms, and maybe avoiding collisions on using the term "graph", would be a cleaner pattern.
