### PR TITLE
Adds additional format responder in PURL controller for redirection to manifest

### DIFF
--- a/app/controllers/purl_controller.rb
+++ b/app/controllers/purl_controller.rb
@@ -12,6 +12,7 @@ class PurlController < ApplicationController
     respond_to do |f|
       f.html { redirect_to url }
       f.json { render json: { url: url }.to_json }
+      f.iiif { redirect_to url + '/manifest' }
     end
   end
 
@@ -48,7 +49,7 @@ class PurlController < ApplicationController
 
     OBJECT_LOOKUPS = {
       MultiVolumeWork => /^\w{3}\d{4}$/,
-      ScannedResource => /^\w{3}\d{4}$/
+      ScannedResource => /^\w{3,}\d{4,}$/
     }.freeze
 
     def set_object

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -8,3 +8,4 @@ Mime::Type.register "text/turtle", :ttl
 Mime::Type.register 'application/x-endnote-refer', :endnote
 Mime::Type.register "application/universalviewer", :uv
 Mime::Type.register "image/jp2", :jp2
+Mime::Type.register "application/json", :iiif

--- a/spec/controllers/purl_controller_spec.rb
+++ b/spec/controllers/purl_controller_spec.rb
@@ -27,11 +27,9 @@ describe PurlController do
     before do
       sign_in user
       file_set
+      get :formats, id: id, format: format
     end
     context "when in jp2" do
-      before do
-        get :formats, id: id, format: format
-      end
       let(:id) { file_set.source_metadata_identifier }
       let(:format) { 'jp2' }
       let(:model) { file_set.has_model[0] }
@@ -72,6 +70,13 @@ describe PurlController do
 
           it 'renders a json response' do
             expect(JSON.parse(response.body)['url']).to match Regexp.escape(target_path)
+          end
+        end
+        context "when in iiif" do
+          let(:format) { 'iiif' }
+
+          it 'redirects to the IIIF manifest' do
+            expect(response).to redirect_to target_path + '/manifest'
           end
         end
       end


### PR DESCRIPTION
Expands on pattern used for redirection to explicit file formats and endpoints via the `respond_to` mechanism in the controller.  This is needed to facilitate access to manifests via PURLs from external consumers (i.e. embedded Universal Viewer)