### PR TITLE
Fixing accidental breakage from PR #201 when new mime type registered

### DIFF
--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -8,4 +8,4 @@ Mime::Type.register "text/turtle", :ttl
 Mime::Type.register 'application/x-endnote-refer', :endnote
 Mime::Type.register "application/universalviewer", :uv
 Mime::Type.register "image/jp2", :jp2
-Mime::Type.register "application/json", :iiif
+Mime::Type.register "text/json", :iiif


### PR DESCRIPTION
Fixing accidental breakage from #201 for ESSI-585 when `application/json` type was registered as `iiif`.