### PR TITLE
Refactoring PURL controller to allow for variable segments in identifier

### DIFF
--- a/app/controllers/purl_controller.rb
+++ b/app/controllers/purl_controller.rb
@@ -48,8 +48,8 @@ class PurlController < ApplicationController
   private
 
     OBJECT_LOOKUPS = {
-      MultiVolumeWork => /^\w{3}\d{4}$/,
-      ScannedResource => /^\w{3,}\d{4,}$/
+      MultiVolumeWork => /^[a-zA-Z\/]{0,}\w{3}\d{4}$/,
+      ScannedResource => /^[a-zA-Z\/]{0,}\w{3,}\d{4,}$/
     }.freeze
 
     def set_object
@@ -59,7 +59,8 @@ class PurlController < ApplicationController
       OBJECT_LOOKUPS.each do |klass, match_pattern|
         if @id.match match_pattern
           @solr_hit = klass.search_with_conditions(
-            { source_metadata_identifier_tesim: @id }, rows: 1
+            /\// =~ @id ? { identifier_tesim: @id } : { source_metadata_identifier: @id },
+            rows: 1
           ).first
           @subfolder = klass.to_s.pluralize.underscore
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,7 +115,7 @@ Rails.application.routes.draw do
   get '/robots.:format' => 'pages#robots'
 
   # Purl redirects
-  get '/purl/:id', to: 'purl#default', as: 'default_purl'
+  get '/purl/*id', to: 'purl#default', as: 'default_purl'
   get '/purl/formats/:id', to: 'purl#formats', as: 'formats_purl'
 
   # iiif search API

--- a/spec/controllers/purl_controller_spec.rb
+++ b/spec/controllers/purl_controller_spec.rb
@@ -7,6 +7,7 @@ describe PurlController do
                        user: user,
                        title: ['Dummy Title'],
                        state: 'complete',
+                       identifier: 'http://purl.dlib.indiana.edu/iudl/variations/score/BHR9405',
                        source_metadata_identifier: 'BHR9405')
   }
   let(:file_set) {
@@ -99,6 +100,14 @@ describe PurlController do
       context "when for a specific page" do
         let(:id) { multi_volume_work.source_metadata_identifier + '-9-0042' }
         let(:target_path) { curation_concerns_multi_volume_work_path(multi_volume_work) + '#?m=8&cv=41' }
+
+        include_examples "responses for matches"
+      end
+      context "when a full PURL matches" do
+        let(:id) { 'iudl/variations/score/BHR9405' }
+        let(:target_path) {
+          curation_concerns_scanned_resource_path(scanned_resource)
+        }
 
         include_examples "responses for matches"
       end

--- a/spec/routing/purl_routing_spec.rb
+++ b/spec/routing/purl_routing_spec.rb
@@ -4,5 +4,7 @@ RSpec.describe "Purl Routing" do
   it "routes to the default action" do
     expect(get(default_purl_path(id: "1"))) \
       .to route_to controller: "purl", action: "default", id: "1"
+    expect(get("/purl/unit/collection/1")) \
+      .to route_to controller: "purl", action: "default", id: "unit/collection/1"
   end
 end


### PR DESCRIPTION
Widens the scope of PURL pattern matching to allow for matching against full PURLs passed in to the Purl controller.