### PR TITLE
[ESSI-918] Purl routing

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,8 +115,8 @@ Rails.application.routes.draw do
   get '/robots.:format' => 'pages#robots'
 
   # Purl redirects
-  get '/purl/*id', to: 'purl#default', as: 'default_purl'
   get '/purl/formats/:id', to: 'purl#formats', as: 'formats_purl'
+  get '/purl/*id', to: 'purl#default', as: 'default_purl'
 
   # iiif search API
   get '/search/:id', to: 'search#search', as: :search

--- a/spec/routing/purl_routing_spec.rb
+++ b/spec/routing/purl_routing_spec.rb
@@ -1,10 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe "Purl Routing" do
-  it "routes to the default action" do
+  it "routes to the default action by source_metadata_identifier match" do
     expect(get(default_purl_path(id: "1"))) \
       .to route_to controller: "purl", action: "default", id: "1"
+  end
+  it "routes to the default action by identifier match" do
     expect(get("/purl/unit/collection/1")) \
       .to route_to controller: "purl", action: "default", id: "unit/collection/1"
+  end
+  it "routes to the formats action" do
+    expect(get(formats_purl_path(id: "1"))) \
+      .to route_to controller: "purl", action: "formats", id: "1"
   end
 end


### PR DESCRIPTION
Adds missing spec coverage, and reorders the purl routes to prevent *id matches from grabbing formats/:id routes