### PR TITLE
Prepare for CAS under IU Login 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,6 +117,7 @@ gem 'browse-everything', git: 'https://github.com/projecthydra-labs/browse-every
 gem 'bunny'
 gem 'ezid-client'
 gem 'iso-639'
+gem 'mimemagic', '~> 0.3.7'
 # gem 'newrelic_rpm'
 gem 'okcomputer'
 gem "omniauth-cas"
@@ -131,7 +132,7 @@ gem 'sprockets', '~> 3.7.0'
 gem 'sprockets-es6'
 gem 'sprockets-rails', '~> 2.3.3'
 gem 'string_rtl'
-gem 'mimemagic', '~> 0.3.7'
+
 group :staging, :development do
   gem 'ruby-prof'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -131,7 +131,7 @@ gem 'sprockets', '~> 3.7.0'
 gem 'sprockets-es6'
 gem 'sprockets-rails', '~> 2.3.3'
 gem 'string_rtl'
-
+gem 'mimemagic', '~> 0.3.7'
 group :staging, :development do
   gem 'ruby-prof'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -449,7 +449,9 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mimemagic (0.3.2)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_magick (4.9.5)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
@@ -786,6 +788,7 @@ DEPENDENCIES
   kgio
   launchy
   ldap_groups_lookup (~> 0.7.0)
+  mimemagic (~> 0.3.7)
   modernizr-rails
   mysql2
   net-http-persistent (~> 2.9.4)

--- a/bin/ci_kakadu_install.sh
+++ b/bin/ci_kakadu_install.sh
@@ -1,8 +1,8 @@
 if [ ! -d "kakadu" ]; then
   mkdir ~/downloads
-  wget http://kakadusoftware.com/wp-content/uploads/2014/06/KDU77_Demo_Apps_for_Linux-x86-64_150710.zip -O ~/downloads/kakadu.zip
+  wget http://kakadusoftware.com/wp-content/uploads/KDU805_Demo_Apps_for_Linux-x86-64_200602.zip -O ~/downloads/kakadu.zip
   unzip ~/downloads/kakadu.zip
-  mv KDU77_Demo_Apps_for_Linux-x86-64_150710 kakadu
+  mv KDU805_Demo_Apps_for_Linux-x86-64_200602 kakadu
 fi
 sudo cp kakadu/*.so /usr/lib
 sudo cp kakadu/* /usr/bin

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,4 +44,5 @@ Rails.application.configure do
   # config.relative_url_root = "/pmp"
 
   # config.active_job.queue_adapter = :sidekiq
+  config.force_ssl = true
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -254,10 +254,10 @@ Devise.setup do |config|
   # setting up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
   config.omniauth :cas,
-                  host: 'cas.iu.edu',
-                  login_url: '/cas/login',
-                  service_validate_url: '/cas/serviceValidate',
-                  logout_url: '/cas/logout',
+                  host: ENV['CAS_HOST'] || 'idp-stg.login.iu.edu',
+                  login_url: ENV['CAS_LOGIN_URL'] || '/idp/profile/cas/login',
+                  service_validate_url: ENV['CAS_VALIDATE_URL'] || '/idp/profile/cas/serviceValidate',
+                  logout_url: ENV['CAS_LOGOUT_URL'] || '/idp/profile/cas/logout',
                   ssl: true
 
   # ==> Warden configuration


### PR DESCRIPTION
In order to prepare for authenticating to CAS under IU Login 2.0, this PR allows full configuration of CAS parameters via the secrets environment file. Incidentally sets config.force_ssl = true for the development environment; IU CAS requires the callback service to be secure, so even developer the stack must run Rails via SSL. 