### PR TITLE
Update config for yaz proxy

### DIFF
--- a/app/services/manifest_builder/see_also_builder.rb
+++ b/app/services/manifest_builder/see_also_builder.rb
@@ -6,7 +6,8 @@ class ManifestBuilder
     end
 
     def apply(manifest)
-      manifest.see_also = see_also_hash if bibdata?
+      # TODO: re-enable, or deprecate
+      # manifest.see_also = see_also_hash if bibdata?
       manifest
     end
 

--- a/config/config.yml
+++ b/config/config.yml
@@ -52,10 +52,11 @@ defaults: &defaults
     mint: false
     update: false
   manifest_builder:
-    see_also_hash:
-      id: <%= ENV["PMP_MANIFEST_SEE_ALSO_URL"] || 'http://dlib.indiana.edu:9000/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=%s&recordSchema=marcxml&version=1.1' %>
+    see_also_hash: # TODO: re-enable or deprecate
+      id: <%= ENV["PMP_MANIFEST_SEE_ALSO_URL"] || 'http://metadata.remote.service.url/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=%s&recordSchema=marcxml&version=1.1' %>
       format: 'application/xml'
   metadata:
+    remote_lookup: <%= ENV["PMP_METADATA_REMOTE_LOOKUP"] || 'http://metadata.remote.service.url' %>
     url: 'https://purl.dlib.indiana.edu/iudl/iucat/%s'
     editable:
     - :identifier

--- a/lib/iu_metadata/client.rb
+++ b/lib/iu_metadata/client.rb
@@ -38,12 +38,16 @@ module IuMetadata
       data
     end
 
+    private_class_method def self.remote_metadata_lookup_url
+      Plum.config.dig(:metadata, :remote_lookup)
+    end
+
     private_class_method def self.retrieve_mods(id)
-      conn = Faraday.new(url: 'http://dlib.indiana.edu:9000')
+      conn = Faraday.new(url: remote_metadata_lookup_url)
       response = conn.get do |req|
         req.url '/iucatextract'
         req.params['query'] = "cql.serverChoice=#{id}"
-        req.params['recordSchema'] = 'mods'
+        req.params['recordSchema'] = 'MODS'
         req.params['operation'] = 'searchRetrieve'
         req.params['version'] = '1.1'
         req.params['maximumRecords'] = '1'
@@ -52,7 +56,7 @@ module IuMetadata
     end
 
     private_class_method def self.retrieve_marc(id)
-      conn = Faraday.new(url: 'http://dlib.indiana.edu:9000')
+      conn = Faraday.new(url: remote_metadata_lookup_url)
       response = conn.get do |req|
         req.url '/iucatextract'
         req.params['query'] = "cql.serverChoice=#{id}"

--- a/spec/cassettes/bibdata-abe9721.yml
+++ b/spec/cassettes/bibdata-abe9721.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://dlib.indiana.edu:9000/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=ABE9721&recordSchema=marcxml&version=1.1
+    uri: http://metadata.remote.service.url/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=ABE9721&recordSchema=marcxml&version=1.1
     body:
       encoding: US-ASCII
       string: ''
@@ -207,7 +207,7 @@ http_interactions:
   recorded_at: Mon, 10 Oct 2016 20:18:20 GMT
 - request:
     method: get
-    uri: http://dlib.indiana.edu:9000/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=ABE9721&recordSchema=mods&version=1.1
+    uri: http://metadata.remote.service.url/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=ABE9721&recordSchema=MODS&version=1.1
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/bibdata-bhr9405.yml
+++ b/spec/cassettes/bibdata-bhr9405.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://dlib.indiana.edu:9000/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=bhr9405&recordSchema=marcxml&version=1.1
+    uri: http://metadata.remote.service.url/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=bhr9405&recordSchema=marcxml&version=1.1
     body:
       encoding: US-ASCII
       string: ''
@@ -123,7 +123,7 @@ http_interactions:
   recorded_at: Fri, 16 Sep 2016 18:51:00 GMT
 - request:
     method: get
-    uri: http://dlib.indiana.edu:9000/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=bhr9405&recordSchema=mods&version=1.1
+    uri: http://metadata.remote.service.url/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=bhr9405&recordSchema=MODS&version=1.1
     body:
       encoding: US-ASCII
       string: ''
@@ -208,7 +208,7 @@ http_interactions:
   recorded_at: Fri, 16 Sep 2016 18:51:00 GMT
 - request:
     method: get
-    uri: http://dlib.indiana.edu:9000/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=BHR9405&recordSchema=marcxml&version=1.1
+    uri: http://metadata.remote.service.url/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=BHR9405&recordSchema=marcxml&version=1.1
     body:
       encoding: US-ASCII
       string: ''
@@ -329,7 +329,7 @@ http_interactions:
   recorded_at: Mon, 10 Oct 2016 20:16:47 GMT
 - request:
     method: get
-    uri: http://dlib.indiana.edu:9000/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=BHR9405&recordSchema=mods&version=1.1
+    uri: http://metadata.remote.service.url/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=BHR9405&recordSchema=MODS&version=1.1
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/bibdata.yml
+++ b/spec/cassettes/bibdata.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://dlib.indiana.edu:9000/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=2028405&recordSchema=marcxml&version=1.1
+    uri: http://metadata.remote.service.url/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=2028405&recordSchema=marcxml&version=1.1
     body:
       encoding: US-ASCII
       string: ''
@@ -111,7 +111,7 @@ http_interactions:
   recorded_at: Thu, 15 Sep 2016 19:38:57 GMT
 - request:
     method: get
-    uri: http://dlib.indiana.edu:9000/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=2028405&recordSchema=mods&version=1.1
+    uri: http://metadata.remote.service.url/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=2028405&recordSchema=MODS&version=1.1
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/bibdata_not_found.yml
+++ b/spec/cassettes/bibdata_not_found.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://dlib.indiana.edu:9000/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=359850&recordSchema=marcxml&version=1.1
+    uri: http://metadata.remote.service.url/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=359850&recordSchema=marcxml&version=1.1
     body:
       encoding: US-ASCII
       string: ''
@@ -33,7 +33,7 @@ http_interactions:
   recorded_at: Thu, 15 Sep 2016 19:39:00 GMT
 - request:
     method: get
-    uri: http://dlib.indiana.edu:9000/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=359850&recordSchema=mods&version=1.1
+    uri: http://metadata.remote.service.url/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=359850&recordSchema=MODS&version=1.1
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/marc_VAD5427.yml
+++ b/spec/cassettes/marc_VAD5427.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://dlib.indiana.edu:9000/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=VAD5427&recordSchema=marcxml&version=1.1
+    uri: http://metadata.remote.service.url/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=VAD5427&recordSchema=marcxml&version=1.1
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/mods_VAD5427.yml
+++ b/spec/cassettes/mods_VAD5427.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://dlib.indiana.edu:9000/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=VAD5427&recordSchema=mods&version=1.1
+    uri: http://metadata.remote.service.url/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=VAD5427&recordSchema=MODS&version=1.1
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/mods_deadbeef.yml
+++ b/spec/cassettes/mods_deadbeef.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://dlib.indiana.edu:9000/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=missingrecorddeadbeef&recordSchema=mods&version=1.1
+    uri: http://metadata.remote.service.url/iucatextract?maximumRecords=1&operation=searchRetrieve&query=cql.serverChoice=missingrecorddeadbeef&recordSchema=MODS&version=1.1
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
* changes hardcoding of the z39.50 lookup to be configured
  * adds the corresponding configuration value, but does NOT change it to the new server location
    * that needs to be done via (a new) ENV variable or change to `config/config.yml` in deployment
 * updates MODS lookup argument from "mods" to "MODS" -- apparently this changed in the new server, and broke our mods lookup
   * updates vcr cassettes
   
For running the specs:
We're stuck in a bit of dependency hell at present, since the recent puma upgrade dependency (nio4r) now requires ruby 2.4+, but that requires upgrading to a much newer version of webmock, which breaks our specs.  I haven't resolved that in CircleCI, but the local workaround is:

```bash
# have .ruby-version running 2.3.8
# check out earlier Gemfile.lock, before the puma update
$ git checkout 44578056 Gemfile.lock
# within pumpkin, run:
$ fcrepo_wrapper -v --config config/fcrepo_wrapper_test.yml
# within essi, set not pumpkin, solr version to 7.7.1 and run:
$ solr_wrapper -v --config config/solr_wrapper_test.yml
# within pumpkin, run:
$ bundle exec rspec -f doc spec/iu_metadata/client_spec.rb
```
You may also have to comment out this line in `spec/support/fedora_cleaner.rb`:
```ruby
ActiveFedora::Cleaner.clean! if ActiveFedora::Base.count.positive?
```

Marking draft pending decision on updating yazproxy URI