### PR TITLE
[ESSI-1630] retry get_info calls

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -36,5 +36,14 @@ module Pumpkin
     config.action_mailer.default_url_options = { host: "plum.com" }
     config.autoload_paths << Rails.root.join('lib')
     config.autoload_paths += %W[#{config.root}/app/jobs/concerns]
+
+    # https://bibwild.wordpress.com/2016/12/27/a-class_eval-monkey-patching-pattern-with-prepend/
+    config.to_prepare do
+      # Load any monkey-patching extensions in to_prepare for
+      # Rails dev-mode class-reloading.
+      Dir.glob(File.join(File.dirname(__FILE__), "../lib/extensions/extensions.rb")) do |c|
+        Rails.configuration.cache_classes ? require(c) : load(c)
+      end
+    end
   end
 end

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -1,1 +1,2 @@
-# monkeypatches go here
+# adds retry logic for get_info calls
+IIIF::Presentation::ImageResource.include Extensions:: IIIF::Presentation::ImageResource::GetInfoRetry

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -1,0 +1,1 @@
+# monkeypatches go here

--- a/lib/extensions/iiif/presentation/image_resource/get_info_retry.rb
+++ b/lib/extensions/iiif/presentation/image_resource/get_info_retry.rb
@@ -1,4 +1,4 @@
-# unmodified from IIIF::Presentation::ImageResource
+# modified from IIIF::Presentation::ImageResource
 module Extensions
   module IIIF
     module Presentation
@@ -7,8 +7,12 @@ module Extensions
           def self.included(base)
             base.class_eval do
               protected
+              # modified from original to add retry settings
               def self.get_info(svc_id)
                 conn = Faraday.new("#{svc_id}/info.json") do |c|
+                  c.request :retry, max: 2, interval: 0.05,
+                            interval_randomness: 0.5, backoff_factor: 2,
+                            exceptions: [Faraday::Error]
                   c.use Faraday::Response::RaiseError
                   c.use Faraday::Adapter::NetHttp
                 end

--- a/lib/extensions/iiif/presentation/image_resource/get_info_retry.rb
+++ b/lib/extensions/iiif/presentation/image_resource/get_info_retry.rb
@@ -1,0 +1,24 @@
+# unmodified from IIIF::Presentation::ImageResource
+module Extensions
+  module IIIF
+    module Presentation
+      module ImageResource
+        module GetInfoRetry
+          def self.included(base)
+            base.class_eval do
+              protected
+              def self.get_info(svc_id)
+                conn = Faraday.new("#{svc_id}/info.json") do |c|
+                  c.use Faraday::Response::RaiseError
+                  c.use Faraday::Adapter::NetHttp
+                end
+                resp = conn.get # raises exceptions that indicate HTTP problems
+                JSON.parse(resp.body)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently, `IIIF::Presentation::ImageResource` makes requests to loris-dev (or the equivalent) without a retry setting, which can fail with a 503, which breaks loading an entire manifest if this happens for a single image request.

This monkeypatch adds retry settings, which console testing suggests are effective for successfully loading a larger manifest.