### PR TITLE
Rescue from Fedora failures when deleting logical_order

### DIFF
--- a/app/jobs/save_structure_job.rb
+++ b/app/jobs/save_structure_job.rb
@@ -6,7 +6,17 @@ class SaveStructureJob < ActiveJob::Base
   def perform(curation_concern, structure)
     return unless curation_concern.respond_to?(:logical_order)
     # Remove existing logical order object to avoid accumulation of fragments.
-    curation_concern.logical_order.destroy eradicate: true
+    begin
+      curation_concern.logical_order.destroy eradicate: true
+    rescue ActiveFedora::ObjectNotFoundError
+      begin
+        logical_order = ActiveFedora::Base.id_to_uri(curation_concern.id) + "/logical_order"
+        ActiveFedora.fedora.connection.head(logical_order)
+      rescue Ldp::Gone
+        tombstone = ActiveFedora::Base.id_to_uri(curation_concern.id) + "/logical_order/fcr:tombstone"
+        ActiveFedora.fedora.connection.delete(tombstone)
+      end
+    end
     curation_concern.reload
     curation_concern.logical_order.order = structure
     curation_concern.save

--- a/config/initializers/curation_concerns.rb
+++ b/config/initializers/curation_concerns.rb
@@ -59,7 +59,8 @@ CurationConcerns.configure do |config|
   config.working_path = ENV["PMP_UPLOAD_PATH"]
 
   # Set TTL in milliseconds of object locks:
-  config.lock_time_to_live = 600_000 # 10m because we have long running jobs
+  # At least 10m, but potentially equal to configured Faraday timeout because we have long running jobs
+  config.lock_time_to_live = ENV['PMP_OBJECT_LOCK_TTL'] || 600_000
   # Disable retrying to attain a lock because the UI should not retry.
   config.lock_retry_count = 1
 


### PR DESCRIPTION
Saving structure for scores with large page count works the first time in about ~1 minute.  But subsequent edit attempts result in hanging jobs that eventually fail in 18 to 25 minutes with `ActiveFedora::ObjectNotFoundError` .  The operation at the time of failure is when the logical order object is deleted with `logical_order.destroy`, which is why it works the first save but not with edits.

To further complicate things, since deleting `logical_order` doesn't finish successfully, it also does not remove the Fedora tombstone, so that subsequent attempts will result in `Ldp::Gone` until it is manually removed.

Until we can figure out what's going on during that long wait to failure, this PR rescues from the initial "not found" error, and then immediately removes the resulting tombstone so that the save of the actual structure object will succeed.  This builds in an unfortunate ~20 minute wait; to help account for that, this PR also makes the object lock TTL configurable in secrets, so that it is obvious that the user can't attempt a new structure edit/save.  

NOTE:
This was tested live with consistent results in the production Pages Admin instance using `dsx61dx88g` .

Also, the long wait to failure can actually be observed in a terminal with `curl`.  As soon as the job starts to destroy the existing structure, attempting to GET the `logical_order` endpoint will hang at the prompt the full duration that the job takes to fail.  It then returns a 404, the same as the actual job.  So whatever is going on at that time, it is on the Fedora side.